### PR TITLE
Update test_endeavour.py with N71 solar soak tests

### DIFF
--- a/test/test_endeavour.py
+++ b/test/test_endeavour.py
@@ -82,10 +82,11 @@ class TestEndeavour(unittest.TestCase):
         self.assertAlmostEqual(price, expected_price, places=4)
 
     def test_convert_N71_solar_soak_1pm(self):
+        # 2026-02-13 the RRP at 12:55 it was $46 so buy 4.91¢ and sell 10.51¢
         interval_time = datetime(2026, 2, 3, 13, 54, tzinfo=ZoneInfo(time_zone()))
         tariff_code = 'N71'
-        rrp = -34.25
-        expected_price = 0.0
+        rrp = 46
+        expected_price = 10.51
         price = convert(interval_time, tariff_code, rrp)
         self.assertAlmostEqual(price, expected_price, places=4)
 

--- a/test/test_endeavour.py
+++ b/test/test_endeavour.py
@@ -72,6 +72,22 @@ class TestEndeavour(unittest.TestCase):
         price = convert(interval_time, tariff_code, rrp)
         self.assertAlmostEqual(price, expected_price, places=2)
 
+    def test_convert_N71_solar_soak_10am(self):
+        interval_time = datetime(2026, 2, 3, 10, 6, tzinfo=ZoneInfo(time_zone()))
+        tariff_code = 'N71'
+        rrp = -34.25
+        expected_price = 0.0
+        price = convert(interval_time, tariff_code, rrp)
+        self.assertAlmostEqual(price, expected_price, places=4)
+
+    def test_convert_N71_solar_soak_1pm(self):
+        interval_time = datetime(2026, 2, 3, 13, 54, tzinfo=ZoneInfo(time_zone()))
+        tariff_code = 'N71'
+        rrp = -34.25
+        expected_price = 0.0
+        price = convert(interval_time, tariff_code, rrp)
+        self.assertAlmostEqual(price, expected_price, places=4)
+
     def test_convert_unknown_tariff(self):
         interval_time = datetime(2023, 7, 15, 10, 0, tzinfo=ZoneInfo(time_zone()))
         tariff_code = 'N999'

--- a/test/test_endeavour.py
+++ b/test/test_endeavour.py
@@ -73,10 +73,11 @@ class TestEndeavour(unittest.TestCase):
         self.assertAlmostEqual(price, expected_price, places=2)
 
     def test_convert_N71_solar_soak_10am(self):
+        # The RRP in NSW on 2026-02-03 at 10:10am +10 looks to be $22 so the buy price was about 7.90¢ and sell was about 2.37¢
         interval_time = datetime(2026, 2, 3, 10, 6, tzinfo=ZoneInfo(time_zone()))
         tariff_code = 'N71'
-        rrp = -34.25
-        expected_price = 0.0
+        rrp = 22
+        expected_price = 7.9
         price = convert(interval_time, tariff_code, rrp)
         self.assertAlmostEqual(price, expected_price, places=4)
 


### PR DESCRIPTION
includes tests at beginning (10:06am) and end (1:54pm) of the solar soak period