### PR TITLE
Eliminate convert() fall-throughs across all DNSPs

### DIFF
--- a/aemo_to_tariff/ausgrid.py
+++ b/aemo_to_tariff/ausgrid.py
@@ -48,7 +48,11 @@ tariffs_2025_26 = {
         'name': 'Residential ToU',
         'periods': [
             ('Peak', time(15, 0), time(21, 0), 29.2450),
-            ('Off-peak', time(21, 0), time(15, 0), 5.1535)
+            # Off-peak covers all 24 hours so it remains the rate during
+            # shoulder months (Apr/May/Sep/Oct) when Peak is skipped. The
+            # Peak entry above wins when its window matches during a peak
+            # month because periods are evaluated in order.
+            ('Off-peak', time(0, 0), time(23, 59), 5.1535)
         ],
         'peak_months': [11, 12, 1, 2, 3, 6, 7, 8]
     },
@@ -68,7 +72,7 @@ tariffs_2025_26 = {
         'name': 'Small Business ToU',
         'periods': [
             ('Peak', time(15, 0), time(21, 0), 34.8921),
-            ('Off-peak', time(21, 0), time(15, 0), 5.7619)
+            ('Off-peak', time(0, 0), time(23, 59), 5.7619)
         ],
         'peak_months': [11, 12, 1, 2, 3, 6, 7, 8]
     },
@@ -92,7 +96,7 @@ tariffs_2026_27 = {
         'name': 'Residential ToU',
         'periods': [
             ('Peak', time(15, 0), time(21, 0), 32.5164),
-            ('Off-peak', time(21, 0), time(15, 0), 5.3570)
+            ('Off-peak', time(0, 0), time(23, 59), 5.3570)
         ],
         'peak_months': [11, 12, 1, 2, 3, 6, 7, 8]
     },
@@ -112,7 +116,7 @@ tariffs_2026_27 = {
         'name': 'Small Business ToU',
         'periods': [
             ('Peak', time(15, 0), time(21, 0), 39.7570),
-            ('Off-peak', time(21, 0), time(15, 0), 5.8997)
+            ('Off-peak', time(0, 0), time(23, 59), 5.8997)
         ],
         'peak_months': [11, 12, 1, 2, 3, 6, 7, 8]
     },
@@ -204,8 +208,11 @@ def convert(interval_datetime: datetime, tariff_code: str, rrp: float):
 
     current_month = interval_datetime.month
 
-    # Determine if current month is within peak months
-    is_peak_month = current_month in tariff.get('peak_months', [])
+    # Tariffs that don't declare 'peak_months' have non-seasonal peaks (e.g.
+    # EA305 LV business). Only skip the Peak period when the tariff explicitly
+    # restricts it to certain months.
+    peak_months = tariff.get('peak_months')
+    is_peak_month = peak_months is None or current_month in peak_months
 
     for period_name, start, end, rate in tariff['periods']:
         if period_name == 'Peak' and not is_peak_month:

--- a/aemo_to_tariff/endeavour.py
+++ b/aemo_to_tariff/endeavour.py
@@ -82,10 +82,15 @@ tariffs_2025_26 = {
         'peak_months': [11, 12, 1, 2, 3]  # High season: Nov–Mar
     },
     'N19': {
+        # LV demand tariff. The 10:00–14:00 window has no energy charge per
+        # the AER 2025–26 schedule (Solar Soak column blank); add an explicit
+        # period at rate 0 so convert() doesn't fall through to the default
+        # slope/intercept approximation.
         'name': 'LV Seasonal STOU Demand',
         'periods': [
             ('High-season Peak', time(16, 0), time(20, 0), 5.4400),
             ('Low-season Peak', time(16, 0), time(20, 0), 4.8861),
+            ('Solar Soak', time(10, 0), time(14, 0), 0.0),
             ('Off Peak', time(0, 0), time(10, 0), 3.6458),
             ('Off Peak', time(14, 0), time(16, 0), 3.6458),
             ('Off Peak', time(20, 0), time(23, 59), 3.6458)
@@ -161,10 +166,13 @@ tariffs_2026_27 = {
         'peak_months': [11, 12, 1, 2, 3]  # High season: Nov–Mar
     },
     'N19': {
+        # AER 2026–27 lists no Solar Soak energy charge (column blank); add
+        # a 10:00–14:00 period at rate 0 to prevent fall-through.
         'name': 'LV Seasonal STOU Demand',
         'periods': [
             ('High-season Peak', time(16, 0), time(20, 0), 6.1024),
             ('Low-season Peak', time(16, 0), time(20, 0), 5.5284),
+            ('Solar Soak', time(10, 0), time(14, 0), 0.0),
             ('Off Peak', time(0, 0), time(10, 0), 4.2432),
             ('Off Peak', time(14, 0), time(16, 0), 4.2432),
             ('Off Peak', time(20, 0), time(23, 59), 4.2432)
@@ -455,28 +463,24 @@ def convert(interval_datetime: datetime, tariff_code: str, rrp: float):
     current_month = interval_datetime.month
     is_high_season = current_month in [11, 12, 1, 2, 3]
 
-    # Find the applicable period and rate
+    # Find the applicable period and rate. Seasonal selection is driven by
+    # the period name, not the tariff name — N95 'Storage' has 'High-season
+    # Peak' / 'Low-season Peak' periods but its name doesn't contain
+    # 'season', so the previous tariff-name check let the HS rate win in
+    # both seasons.
     for period, start, end, rate in tariff['periods']:
         if start <= interval_time < end:
-            if 'season' in tariff['name'].lower():
-                if is_high_season and 'high' in period.lower():
-                    total_price = rrp_c_kwh + rate
-                    return total_price
-                elif 'low' in period.lower() and not is_high_season:
-                    total_price = rrp_c_kwh + rate
-                    return total_price
-                elif 'solar' in period.lower():
-                    # Solar Soak applies year-round in season tariffs
-                    total_price = rrp_c_kwh + rate
-                    return total_price
-                elif 'off' in period.lower():
-                    total_price = rrp_c_kwh + rate
-                    return total_price
-                else:
-                    continue
-            else:
-                total_price = rrp_c_kwh + rate
-                return total_price
+            period_lower = period.lower()
+            if 'high' in period_lower:
+                if is_high_season:
+                    return rrp_c_kwh + rate
+                continue  # Skip HS period in low season
+            if 'low' in period_lower:
+                if not is_high_season:
+                    return rrp_c_kwh + rate
+                continue  # Skip LS period in high season
+            # Solar Soak, Off Peak, Anytime, Block N etc. apply year-round
+            return rrp_c_kwh + rate
 
     # Otherwise, this terrible approximation
     slope = 1.037869032618134

--- a/aemo_to_tariff/evoenergy.py
+++ b/aemo_to_tariff/evoenergy.py
@@ -39,9 +39,15 @@ def battery_tariffs(customer_type: str):
 tariffs_2025_26 = {
     '015': {
         'name': 'Residential TOU Network (closed)',
+        # Peak applies only in peak_months. In shoulder months (Apr/May/Sep/Oct)
+        # the 7–9 and 17–20 windows become shoulder, so duplicate Shoulder
+        # entries are listed at those times — Peak is checked first and wins
+        # during peak months because periods are evaluated in order.
         'periods': [
             ('Peak', time(7, 0), time(9, 0), 16.095),
             ('Peak', time(17, 0), time(20, 0), 16.095),
+            ('Shoulder', time(7, 0), time(9, 0), 8.199),
+            ('Shoulder', time(17, 0), time(20, 0), 8.199),
             ('Shoulder', time(9, 0), time(17, 0), 8.199),
             ('Shoulder', time(20, 0), time(22, 0), 8.199),
             ('Off-peak', time(22, 0), time(7, 0), 4.828)
@@ -53,6 +59,8 @@ tariffs_2025_26 = {
         'periods': [
             ('Peak', time(7, 0), time(9, 0), 16.095),
             ('Peak', time(17, 0), time(20, 0), 16.095),
+            ('Shoulder', time(7, 0), time(9, 0), 8.199),
+            ('Shoulder', time(17, 0), time(20, 0), 8.199),
             ('Shoulder', time(9, 0), time(17, 0), 8.199),
             ('Shoulder', time(20, 0), time(22, 0), 8.199),
             ('Off-peak', time(22, 0), time(7, 0), 4.828)
@@ -74,9 +82,14 @@ tariffs_2025_26 = {
     },
     '018': {
         'name': 'New Residential TOU Network XMC',
+        # In shoulder months Peak is skipped; the duplicate Off-peak entries at
+        # 7–9 and 17–21 prevent fall-through. (AER 2026–27 lists no separate
+        # shoulder rate for this tariff, so peak windows revert to off-peak.)
         'periods': [
             ('Peak', time(7, 0), time(9, 0), 16.184),
             ('Peak', time(17, 0), time(21, 0), 16.184),
+            ('Off-peak', time(7, 0), time(9, 0), 5.665),
+            ('Off-peak', time(17, 0), time(21, 0), 5.665),
             ('Solar Soak', time(11, 0), time(15, 0), 3.261),
             ('Off-peak', time(21, 0), time(7, 0), 5.665),
             ('Off-peak', time(9, 0), time(11, 0), 5.665),
@@ -90,6 +103,8 @@ tariffs_2025_26 = {
         'periods': [
             ('Peak', time(7, 0), time(9, 0), 16.184),
             ('Peak', time(17, 0), time(21, 0), 16.184),
+            ('Off-peak', time(7, 0), time(9, 0), 5.665),
+            ('Off-peak', time(17, 0), time(21, 0), 5.665),
             ('Solar Soak', time(11, 0), time(15, 0), 3.261),
             ('Off-peak', time(21, 0), time(7, 0), 5.665),
             ('Off-peak', time(9, 0), time(11, 0), 5.665),
@@ -116,6 +131,8 @@ tariffs_2026_27 = {
         'periods': [
             ('Peak', time(7, 0), time(9, 0), 15.877),
             ('Peak', time(17, 0), time(20, 0), 15.877),
+            ('Shoulder', time(7, 0), time(9, 0), 7.030),
+            ('Shoulder', time(17, 0), time(20, 0), 7.030),
             ('Shoulder', time(9, 0), time(17, 0), 7.030),
             ('Shoulder', time(20, 0), time(22, 0), 7.030),
             ('Off-peak', time(22, 0), time(7, 0), 3.442)
@@ -127,6 +144,8 @@ tariffs_2026_27 = {
         'periods': [
             ('Peak', time(7, 0), time(9, 0), 15.877),
             ('Peak', time(17, 0), time(20, 0), 15.877),
+            ('Shoulder', time(7, 0), time(9, 0), 7.030),
+            ('Shoulder', time(17, 0), time(20, 0), 7.030),
             ('Shoulder', time(9, 0), time(17, 0), 7.030),
             ('Shoulder', time(20, 0), time(22, 0), 7.030),
             ('Off-peak', time(22, 0), time(7, 0), 3.442)
@@ -151,6 +170,8 @@ tariffs_2026_27 = {
         'periods': [
             ('Peak', time(7, 0), time(9, 0), 16.049),
             ('Peak', time(17, 0), time(21, 0), 16.049),
+            ('Off-peak', time(7, 0), time(9, 0), 4.351),
+            ('Off-peak', time(17, 0), time(21, 0), 4.351),
             ('Solar Soak', time(11, 0), time(15, 0), 1.779),
             ('Off-peak', time(21, 0), time(7, 0), 4.351),
             ('Off-peak', time(9, 0), time(11, 0), 4.351),
@@ -164,6 +185,8 @@ tariffs_2026_27 = {
         'periods': [
             ('Peak', time(7, 0), time(9, 0), 16.049),
             ('Peak', time(17, 0), time(21, 0), 16.049),
+            ('Off-peak', time(7, 0), time(9, 0), 3.534),
+            ('Off-peak', time(17, 0), time(21, 0), 3.534),
             ('Solar Soak', time(11, 0), time(15, 0), 1.630),
             ('Off-peak', time(21, 0), time(7, 0), 3.534),
             ('Off-peak', time(9, 0), time(11, 0), 3.534),
@@ -298,7 +321,11 @@ def convert(interval_datetime: datetime, tariff_code: str, rrp: float):
     rrp_c_kwh = rrp / 10
     tariff = get_tariffs(interval_datetime)[tariff_code]
     gst = 1.1
-    is_peak_month = current_month in tariff.get('peak_months', [])
+    # Tariffs that don't declare 'peak_months' have non-seasonal peaks (e.g.
+    # tariff 090 General Component Charge Applicability). Only skip the Peak
+    # period when the tariff explicitly restricts it to certain months.
+    peak_months = tariff.get('peak_months')
+    is_peak_month = peak_months is None or current_month in peak_months
 
     # Find the applicable period and rate
     for period_name, start, end, rate in tariff['periods']:
@@ -341,7 +368,8 @@ def convert_feed_in_tariff(interval_datetime: datetime, tariff_code: str, rrp: f
         return rrp_c_kwh
 
     current_month = interval_datetime.month
-    is_peak_month = current_month in feed_in_tariff.get('peak_months', [])
+    peak_months = feed_in_tariff.get('peak_months')
+    is_peak_month = peak_months is None or current_month in peak_months
 
     for period_name, start, end, rate in feed_in_tariff['periods']:
         if period_name == 'Peak' and not is_peak_month:

--- a/aemo_to_tariff/sapower.py
+++ b/aemo_to_tariff/sapower.py
@@ -222,10 +222,16 @@ tariffs_2025_26 = {
         ]
     },
     'B2R': {
+        # Two-rate business tariff. Previously the periods only covered 16:00–
+        # 10:00 next day, leaving 10:00–16:00 falling through to the slope/
+        # intercept default. Added an explicit 'Solar Sponge' window at the
+        # off-peak rate (AER 2026–27 lists no separate solar-sponge usage rate
+        # for B2R, so it matches off-peak).
         'name': 'Business Two Rate',
         'periods': [
             ('Peak', time(17, 0), time(21, 0), None, 20.65),
             ('Shoulder', time(16, 0), time(17, 0), None, 10.32),
+            ('Solar Sponge', time(10, 0), time(16, 0), None, 7.26),
             ('Off-peak', time(21, 0), time(10, 0), None, 7.26)
         ]
     },
@@ -323,10 +329,12 @@ tariffs_2026_27 = {
         ]
     },
     'B2R': {
+        # See 2025–26 dict for the rationale on the Solar Sponge window.
         'name': 'Business Two Rate',
         'periods': [
             ('Peak', time(17, 0), time(21, 0), None, 21.57),
             ('Shoulder', time(16, 0), time(17, 0), None, 10.78),
+            ('Solar Sponge', time(10, 0), time(16, 0), None, 7.26),
             ('Off-peak', time(21, 0), time(10, 0), None, 7.26)
         ]
     },

--- a/test/test_ausgrid.py
+++ b/test/test_ausgrid.py
@@ -5,13 +5,16 @@ from aemo_to_tariff.ausgrid import convert_feed_in_tariff, time_zone, convert, c
 
 class TestAusgrid(unittest.TestCase):
     def test_ea_025_peak(self):
+        # April is a shoulder month for EA025 (peak_months = Nov-Mar + Jun-Aug),
+        # so Peak is skipped and off-peak applies at 5.1535 c/kWh in 2025–26.
+        # Previously this test asserted the buggy slope/intercept fallback of
+        # ~22.13 because the off-peak window didn't cover 17:45.
         interval_time = datetime(2025, 4, 22, 17, 45, tzinfo=ZoneInfo(time_zone()))
         tariff_code = 'EA025'
         rrp = 136.7
-        expected_price = 22.13
+        expected_price = (rrp / 10 + 5.1535) * 1.12
         price = convert(interval_time, tariff_code, rrp)
-        loss_factor = expected_price / price
-        self.assertAlmostEqual(price * 1.12, expected_price, places=1)
+        self.assertAlmostEqual(price * 1.12, expected_price, places=2)
         feed_in = convert_feed_in_tariff(interval_time, tariff_code, rrp)
         self.assertAlmostEqual(feed_in, 13.66, places=1)
     
@@ -47,13 +50,16 @@ class TestAusgrid(unittest.TestCase):
         self.assertAlmostEqual(price, expected_price, places=1)
 
     def test_ea_305_peak(self):
+        # EA305 LV business is non-seasonal (no peak_months) — Peak applies
+        # year-round, 15:00–22:59 at 7.3723 c/kWh in 2025–26.
+        # Previously this assertion targeted the buggy slope/intercept default
+        # of ~22.1471 because Peak was being skipped on every tariff without
+        # peak_months. Now it asserts the real Peak rate.
         interval_time = datetime(2025, 4, 22, 17, 45, tzinfo=ZoneInfo(time_zone()))
-        tariff_code = 'EA305'
         rrp = 136.7
-        expected_price = 22.1471
-        price = convert(interval_time, tariff_code, rrp)
-        loss_factor = expected_price / price
-        self.assertAlmostEqual(price * 1.12, expected_price, places=1)
+        expected_price = (rrp / 10 + 7.3723) * 1.12
+        price = convert(interval_time, 'EA305', rrp)
+        self.assertAlmostEqual(price * 1.12, expected_price, places=2)
     
     def test_ea_305_off_peak(self):
         interval_time = datetime(2025, 4, 22, 12, 45, tzinfo=ZoneInfo(time_zone()))
@@ -69,3 +75,20 @@ class TestAusgrid(unittest.TestCase):
         interval_time = datetime(2026, 7, 22, 17, 45, tzinfo=ZoneInfo(time_zone()))
         price = convert(interval_time, 'EA025', 136.7)
         self.assertAlmostEqual(price, 13.67 + 32.5164, places=2)
+
+    def test_ea_305_sunday_evening(self):
+        # Regression: EA305 has no 'peak_months' field. Previously this caused
+        # is_peak_month to be False year-round → Peak skipped → fall-through to
+        # the slope/intercept default (~5.59 c/kWh + RRP). Should return Peak
+        # rate at Sun 18:00.
+        interval_time = datetime(2026, 1, 18, 18, 0, tzinfo=ZoneInfo(time_zone()))
+        price = convert(interval_time, 'EA305', 0.0)
+        self.assertAlmostEqual(price, 7.3723, places=4)
+
+    def test_ea_025_shoulder_month_offpeak(self):
+        # Regression: EA025 in a shoulder month (Apr/May/Sep/Oct) at peak time.
+        # Peak is skipped (not in peak_months), and the off-peak window now
+        # covers all 24h, so off-peak rate should apply.
+        interval_time = datetime(2025, 4, 22, 17, 45, tzinfo=ZoneInfo(time_zone()))
+        price = convert(interval_time, 'EA025', 0.0)
+        self.assertAlmostEqual(price, 5.1535, places=4)

--- a/test/test_endeavour.py
+++ b/test/test_endeavour.py
@@ -137,3 +137,22 @@ class TestEndeavour(unittest.TestCase):
         interval_time = datetime(2025, 7, 14, 11, 30, tzinfo=ZoneInfo(time_zone()))
         price = convert(interval_time, 'N71', 22.0)
         self.assertAlmostEqual(price, 2.2 + 3.4252, places=2)
+
+    def test_N19_solar_soak_zero_energy(self):
+        # Regression: N19 LV demand previously had no period covering 10–14, so
+        # midday lookups fell through to the slope/intercept default. The AER
+        # 2025–26 schedule has no Solar Soak energy charge (blank column); we
+        # model it as an explicit Solar Soak period at rate 0.
+        interval_time = datetime(2025, 9, 1, 11, 30, tzinfo=ZoneInfo(time_zone()))
+        price = convert(interval_time, 'N19', 22.0)
+        self.assertAlmostEqual(price, 2.2 + 0.0, places=2)
+
+    def test_N95_seasonality(self):
+        # Regression: N95 'Storage' has seasonal periods but its tariff name
+        # doesn't contain 'season', which previously caused the convert() loop
+        # to fall back to the simple "first matching period" branch and apply
+        # the HS rate year-round. Verify HS rate in Jan, LS rate in Jul.
+        hs = datetime(2026, 1, 14, 18, 0, tzinfo=ZoneInfo(time_zone()))
+        ls = datetime(2025, 7, 14, 18, 0, tzinfo=ZoneInfo(time_zone()))
+        self.assertAlmostEqual(convert(hs, 'N95', 0.0), 13.1329, places=4)
+        self.assertAlmostEqual(convert(ls, 'N95', 0.0), 5.1784, places=4)

--- a/test/test_evoenergy.py
+++ b/test/test_evoenergy.py
@@ -47,3 +47,28 @@ class TestEvoenergy(unittest.TestCase):
         interval_time = datetime(2026, 7, 20, 18, 0, tzinfo=ZoneInfo('Australia/Sydney'))
         price = evoenergy.convert(interval_time, '017', 100.0)
         self.assertAlmostEqual(price, 10.0 + 16.049 * 1.1, places=2)
+
+    def test_evoenergy_090_midday(self):
+        # Regression: tariff 090 has no peak_months. Previously is_peak_month
+        # defaulted to False, so the 'Peak' period (7am–5pm) was always
+        # skipped and any midday lookup fell through to the slope/intercept
+        # default. Verify Peak now applies.
+        interval_time = datetime(2025, 9, 16, 11, 0, tzinfo=ZoneInfo('Australia/Sydney'))
+        price = evoenergy.convert(interval_time, '090', 0.0)
+        # 2025–26 schedule peak rate 17.518 c/kWh × 1.1 GST = 19.27 c/kWh
+        self.assertAlmostEqual(price, 17.518 * 1.1, places=2)
+
+    def test_evoenergy_015_shoulder_month_morning(self):
+        # Regression: 015 has peak_months [11,12,1,2,3,6,7,8]. In shoulder
+        # months (Apr/May/Sep/Oct) at 8am Peak is skipped and previously no
+        # other period covered 7-9, so the lookup fell through to the
+        # slope/intercept default. Should now return Shoulder rate.
+        interval_time = datetime(2025, 4, 15, 8, 0, tzinfo=ZoneInfo('Australia/Sydney'))
+        price = evoenergy.convert(interval_time, '015', 0.0)
+        self.assertAlmostEqual(price, 8.199 * 1.1, places=2)
+
+    def test_evoenergy_018_shoulder_month_evening(self):
+        # Same fix on 018: in shoulder months 17–21 should return Off-peak.
+        interval_time = datetime(2025, 10, 15, 18, 0, tzinfo=ZoneInfo('Australia/Sydney'))
+        price = evoenergy.convert(interval_time, '018', 0.0)
+        self.assertAlmostEqual(price, 5.665 * 1.1, places=2)

--- a/test/test_sapower.py
+++ b/test/test_sapower.py
@@ -225,3 +225,11 @@ class TestSAPower(unittest.TestCase):
         interval_time = datetime(2026, 7, 15, 18, 0, tzinfo=ZoneInfo('Australia/Adelaide'))
         price = sapower.convert(interval_time, 'RTOU', 100.0)
         self.assertAlmostEqual(price, 10.0 + 21.33, places=2)
+
+    def test_b2r_solar_sponge_window(self):
+        # Regression: B2R previously had no period covering 10:00–16:00, so
+        # midday lookups returned the slope/intercept default (~5.59 + RRP).
+        # The window is now an explicit Solar Sponge at the off-peak rate.
+        interval_time = datetime(2025, 9, 1, 12, 0, tzinfo=ZoneInfo('Australia/Adelaide'))
+        price = sapower.convert(interval_time, 'B2R', 0.0)
+        self.assertAlmostEqual(price, 7.26, places=2)


### PR DESCRIPTION
A fuzz over every hour × every month × every tariff revealed five classes of latent bugs where convert() silently fell back to a linear slope/intercept approximation instead of returning the tariff rate.

1. Ausgrid EA305 — non-seasonal Peak was being skipped year-round. EA305 has no `peak_months`, but `tariff.get('peak_months', [])` returned `[]`, so `is_peak_month` was always False and the Peak period was always skipped. Same bug in Evoenergy 090. Fixed by skipping Peak only when `peak_months` is explicitly set AND the current month is not in it.

2. Ausgrid EA025 / EA225 in shoulder months — the off-peak window (21:00–15:00 wrap) didn't cover 15:00–21:00, so in Apr/May/Sep/Oct at peak time the lookup fell through. Extended off-peak to 0–23:59 so it remains the rate during shoulder months (Peak still wins in peak months because it's evaluated first).

3. Evoenergy 015/016/018/026 in shoulder months — same root cause. Added duplicate Shoulder/Off-peak entries at the peak windows (7–9 and 17–20/21) so the lookup remains covered when Peak is skipped.

4. SAPN B2R — the original tariff covered 16:00–10:00 next day, leaving 10:00–16:00 falling through every day. Added an explicit Solar Sponge period at the off-peak rate, matching the AER 2026–27 schedule that lists no separate solar-sponge usage rate for B2R.

5. Endeavour N95 (Storage) — tariff name doesn't contain 'season' but its periods are 'High-season Peak' / 'Low-season Peak', so the convert() loop's tariff-name guard returned the first matching period (HS rate) year-round. Rewrote the seasonal check to drive off period names, not tariff name. Storage now correctly applies the low-season rate Apr–Oct.

6. Endeavour N19 — its periods covered everything except 10:00–14:00 (Solar Soak). AER lists no energy charge in that window; added a Solar Soak period at rate 0 so convert returns the spot price (matching what the customer actually pays — they pay only the demand fee during that window).

Tests updated:
- Existing Ausgrid `test_ea_025_peak` and `test_ea_305_peak` were asserting the buggy slope/intercept fallback; updated to assert the real rates.
- Added regression tests for every fix.

Verified with an exhaustive fuzz: 10 networks × 2 schedules × 4 months × 24 hours × every tariff → zero fall-throughs. 118 tests pass.