### PR TITLE
feat: add Energex Residential Two-Way Tariff Trial (NTC 96200)

### DIFF
--- a/aemo_to_tariff/energex.py
+++ b/aemo_to_tariff/energex.py
@@ -622,9 +622,14 @@ def convert_two_way_tariff(interval_datetime: datetime, rrp: float, is_export: b
     Returns:
     - float: Price in c/kWh. For import: spot + network. For export: spot + network adjustment.
     """
+    rrp_c_kwh = rrp / 10
+
+    if not _use_2026_prices(interval_datetime):
+        # NTC 96200 does not exist before 1 July 2026 — return spot-only
+        return rrp_c_kwh
+
     local = interval_datetime.astimezone(ZoneInfo(time_zone()))
     t = local.time()
-    rrp_c_kwh = rrp / 10
     summer = _is_summer(local)
 
     if is_export:

--- a/aemo_to_tariff/energex.py
+++ b/aemo_to_tariff/energex.py
@@ -18,6 +18,12 @@ def _use_2026_prices(interval_time=None) -> bool:
     return interval_time >= PRICE_TRANSITION_DATE
 
 
+def _is_summer(interval_time: datetime) -> bool:
+    """Return True if the interval falls in the summer season (Nov–Mar)."""
+    local_time = interval_time.astimezone(ZoneInfo(time_zone()))
+    return local_time.month in (11, 12, 1, 2, 3)
+
+
 def battery_tariffs(customer_type: str):
     """
     Get the battery tariff for a given customer type.
@@ -29,7 +35,7 @@ def battery_tariffs(customer_type: str):
     - str: The battery tariff code.
     """
     if customer_type == 'Residential':
-        return {'import': ['6900'], 'export': ['6900X']}
+        return {'import': ['6900', '96200'], 'export': ['6900X', '96200X']}
     elif customer_type == 'Business':
         return {'import': ['6800'], 'export': ['6800X']}
     else:
@@ -92,6 +98,7 @@ daily_fees_2026_27 = {
     '7200': 9.134,  # LV Demand Time-of-Use
     '8100': 37.740,  # Demand Large (legacy)
     '8300': 10.317,  # Demand Small
+    '96200': 0.651,  # Residential Two-Way Tariff Trial
 }
 
 
@@ -371,6 +378,17 @@ tariffs_2026_27 = {
             ('Shoulder', time(0, 0), time(10, 59), 19.540)
         ],
     },
+    '96200': {
+        'name': 'Residential Two-Way Tariff Trial',
+        'seasonal': True,
+        'rate': {
+            'Peak': 19.533,
+            'Shoulder': 6.069,
+            'Off-Peak': 0.434,
+            'ExportCharge': 2.210,
+            'ExportReward': -12.195,
+        }
+    },
 }
 
 
@@ -435,6 +453,8 @@ def translate_tariff(tariff_code: str):
     - str: The canonical tariff code for lookup.
     """
     code = str(tariff_code)
+    if code == '96200':  # Two-Way Tariff Trial — do not truncate
+        return code
     if len(code) == 4:
         prefix = code[:2]
         return prefix + '00'
@@ -575,6 +595,58 @@ def convert_feed_in_tariff(interval_datetime: datetime, tariff_code: str, rrp: f
 
     return rrp_c_kwh
 
+def convert_two_way_tariff(interval_datetime: datetime, rrp: float, is_export: bool = False) -> float:
+    """
+    Convert RRP to c/kWh for the Energex Residential Two-Way Tariff Trial (NTC 96200).
+
+    Import periods:
+      Summer (Nov-Mar):
+        Peak:     17:00-20:00  → 19.533 c/kWh
+        Off-Peak: 09:00-15:00  → 0.434 c/kWh
+        Shoulder: all other    → 6.069 c/kWh
+      Non-Summer (Apr-Oct):
+        Off-Peak: 09:00-15:00  → 0.434 c/kWh
+        Shoulder: all other    → 6.069 c/kWh  (no peak period)
+
+    Export periods:
+      Summer:     17:00-20:00  → -12.195 c/kWh (reward/credit)
+      Non-Summer: 11:00-13:00  → +2.210 c/kWh (charge)
+                  10:00-11:00  → 0 (BEL exempt)
+      All other:               → 0 c/kWh
+
+    Parameters:
+    - interval_datetime: The dispatch interval datetime (tz-aware), already adjusted.
+    - rrp: AEMO Regional Reference Price in $/MWh.
+    - is_export: True for export (feed-in), False for import.
+
+    Returns:
+    - float: Price in c/kWh. For import: spot + network. For export: spot + network adjustment.
+    """
+    local = interval_datetime.astimezone(ZoneInfo(time_zone()))
+    t = local.time()
+    rrp_c_kwh = rrp / 10
+    summer = _is_summer(local)
+
+    if is_export:
+        if summer and time(17, 0) <= t < time(20, 0):
+            network = -12.195  # export reward (credit)
+        elif not summer and time(11, 0) <= t < time(13, 0):
+            network = 2.210   # export charge
+        else:
+            network = 0.0     # no charge/reward
+        return rrp_c_kwh + network
+
+    # Import
+    if summer and time(17, 0) <= t < time(20, 0):
+        network = 19.533  # Peak
+    elif time(9, 0) <= t < time(15, 0):
+        network = 0.434   # Off-Peak (all year)
+    else:
+        network = 6.069   # Shoulder (summer: 20-09 + 15-17; non-summer: 15-09)
+
+    return rrp_c_kwh + network
+
+
 def convert(interval_datetime: datetime, tariff_code: str, rrp: float):
     """
     Convert RRP from $/MWh to c/kWh for Energex.
@@ -589,6 +661,12 @@ def convert(interval_datetime: datetime, tariff_code: str, rrp: float):
     """
     interval_datetime = interval_datetime - timedelta(minutes=5)
     tariff_code = translate_tariff(str(tariff_code))
+
+    # Two-Way Tariff Trial — delegate to seasonal handler. interval_datetime is
+    # already adjusted by 5 minutes above, so pass it directly.
+    if tariff_code == '96200':
+        return convert_two_way_tariff(interval_datetime, rrp, is_export=False)
+
     interval_time = interval_datetime.astimezone(ZoneInfo(time_zone())).time()
     rrp_c_kwh = rrp / 10
 

--- a/test/test_energex.py
+++ b/test/test_energex.py
@@ -38,19 +38,19 @@ class TestTwoWayTariff(unittest.TestCase):
 
     def test_import_peak_summer(self):
         # Summer peak: Jan 15, 18:00 → Peak rate 19.533
-        dt = datetime(2026, 1, 15, 18, 0, tzinfo=BRISBANE)
+        dt = datetime(2027, 1, 15, 18, 0, tzinfo=BRISBANE)
         price = energex.convert_two_way_tariff(dt, 100.0, is_export=False)
         self.assertAlmostEqual(price, 10.0 + 19.533, places=2)
 
     def test_import_offpeak_summer(self):
         # Summer off-peak: Jan 15, 12:00 → Off-Peak 0.434
-        dt = datetime(2026, 1, 15, 12, 0, tzinfo=BRISBANE)
+        dt = datetime(2027, 1, 15, 12, 0, tzinfo=BRISBANE)
         price = energex.convert_two_way_tariff(dt, 100.0, is_export=False)
         self.assertAlmostEqual(price, 10.0 + 0.434, places=2)
 
     def test_import_shoulder_summer(self):
         # Summer shoulder: Jan 15, 21:00 → Shoulder 6.069
-        dt = datetime(2026, 1, 15, 21, 0, tzinfo=BRISBANE)
+        dt = datetime(2027, 1, 15, 21, 0, tzinfo=BRISBANE)
         price = energex.convert_two_way_tariff(dt, 100.0, is_export=False)
         self.assertAlmostEqual(price, 10.0 + 6.069, places=2)
 
@@ -68,7 +68,7 @@ class TestTwoWayTariff(unittest.TestCase):
 
     def test_export_reward_summer(self):
         # Summer export reward: Jan 15, 18:00 → -12.195
-        dt = datetime(2026, 1, 15, 18, 0, tzinfo=BRISBANE)
+        dt = datetime(2027, 1, 15, 18, 0, tzinfo=BRISBANE)
         price = energex.convert_two_way_tariff(dt, 100.0, is_export=True)
         self.assertAlmostEqual(price, 10.0 - 12.195, places=2)
 
@@ -90,6 +90,18 @@ class TestTwoWayTariff(unittest.TestCase):
         price = energex.convert_two_way_tariff(dt, 100.0, is_export=True)
         self.assertAlmostEqual(price, 10.0, places=2)
 
+    def test_pre_july_2026_returns_spot_only(self):
+        # Before 1 July 2026 — tariff doesn't exist, should return spot only
+        dt = datetime(2025, 12, 15, 18, 0, tzinfo=BRISBANE)  # summer but pre-2026-27
+        price = energex.convert_two_way_tariff(dt, 100.0, is_export=False)
+        self.assertAlmostEqual(price, 10.0, places=2)  # spot only, no network
+
+    def test_pre_july_2026_export_returns_spot_only(self):
+        # Before 1 July 2026 — export, should return spot only
+        dt = datetime(2025, 12, 15, 18, 0, tzinfo=BRISBANE)
+        price = energex.convert_two_way_tariff(dt, 100.0, is_export=True)
+        self.assertAlmostEqual(price, 10.0, places=2)  # spot only, no network
+
     def test_daily_fee_96200(self):
         interval_time = datetime(2026, 9, 1, 12, 0, tzinfo=BRISBANE)
         self.assertEqual(energex.get_daily_fee('96200', interval_time=interval_time), 0.651)
@@ -100,6 +112,6 @@ class TestTwoWayTariff(unittest.TestCase):
 
     def test_convert_96200_dispatches(self):
         # Ensure convert() with tariff '96200' reaches convert_two_way_tariff
-        dt = datetime(2026, 1, 15, 18, 5, tzinfo=BRISBANE)  # 18:05 → adjusted to 18:00 → peak
+        dt = datetime(2027, 1, 15, 18, 5, tzinfo=BRISBANE)  # 18:05 → adjusted to 18:00 → peak
         price = energex.convert(dt, '96200', 100.0)
         self.assertAlmostEqual(price, 10.0 + 19.533, places=2)

--- a/test/test_energex.py
+++ b/test/test_energex.py
@@ -32,3 +32,74 @@ class TestEnergex(unittest.TestCase):
     def test_get_daily_fee_2026_27(self):
         interval_time = datetime(2026, 9, 1, 12, 0, tzinfo=BRISBANE)
         self.assertEqual(energex.get_daily_fee('6900', 20000, interval_time=interval_time), 0.651)
+
+
+class TestTwoWayTariff(unittest.TestCase):
+
+    def test_import_peak_summer(self):
+        # Summer peak: Jan 15, 18:00 → Peak rate 19.533
+        dt = datetime(2026, 1, 15, 18, 0, tzinfo=BRISBANE)
+        price = energex.convert_two_way_tariff(dt, 100.0, is_export=False)
+        self.assertAlmostEqual(price, 10.0 + 19.533, places=2)
+
+    def test_import_offpeak_summer(self):
+        # Summer off-peak: Jan 15, 12:00 → Off-Peak 0.434
+        dt = datetime(2026, 1, 15, 12, 0, tzinfo=BRISBANE)
+        price = energex.convert_two_way_tariff(dt, 100.0, is_export=False)
+        self.assertAlmostEqual(price, 10.0 + 0.434, places=2)
+
+    def test_import_shoulder_summer(self):
+        # Summer shoulder: Jan 15, 21:00 → Shoulder 6.069
+        dt = datetime(2026, 1, 15, 21, 0, tzinfo=BRISBANE)
+        price = energex.convert_two_way_tariff(dt, 100.0, is_export=False)
+        self.assertAlmostEqual(price, 10.0 + 6.069, places=2)
+
+    def test_import_offpeak_nonsummer(self):
+        # Non-summer off-peak: Jul 15, 12:00 → Off-Peak 0.434
+        dt = datetime(2026, 7, 15, 12, 0, tzinfo=BRISBANE)
+        price = energex.convert_two_way_tariff(dt, 100.0, is_export=False)
+        self.assertAlmostEqual(price, 10.0 + 0.434, places=2)
+
+    def test_import_shoulder_nonsummer(self):
+        # Non-summer shoulder (no peak period): Jul 15, 18:00 → Shoulder 6.069
+        dt = datetime(2026, 7, 15, 18, 0, tzinfo=BRISBANE)
+        price = energex.convert_two_way_tariff(dt, 100.0, is_export=False)
+        self.assertAlmostEqual(price, 10.0 + 6.069, places=2)
+
+    def test_export_reward_summer(self):
+        # Summer export reward: Jan 15, 18:00 → -12.195
+        dt = datetime(2026, 1, 15, 18, 0, tzinfo=BRISBANE)
+        price = energex.convert_two_way_tariff(dt, 100.0, is_export=True)
+        self.assertAlmostEqual(price, 10.0 - 12.195, places=2)
+
+    def test_export_charge_nonsummer(self):
+        # Non-summer export charge 11:00-13:00: Jul 15, 12:00 → +2.210
+        dt = datetime(2026, 7, 15, 12, 0, tzinfo=BRISBANE)
+        price = energex.convert_two_way_tariff(dt, 100.0, is_export=True)
+        self.assertAlmostEqual(price, 10.0 + 2.210, places=2)
+
+    def test_export_bel_exempt(self):
+        # BEL exempt window 10:00-11:00: Jul 15, 10:30 → 0 network
+        dt = datetime(2026, 7, 15, 10, 30, tzinfo=BRISBANE)
+        price = energex.convert_two_way_tariff(dt, 100.0, is_export=True)
+        self.assertAlmostEqual(price, 10.0 + 0.0, places=2)
+
+    def test_export_no_charge_nonsummer_evening(self):
+        # Non-summer evening export: no charge
+        dt = datetime(2026, 7, 15, 20, 0, tzinfo=BRISBANE)
+        price = energex.convert_two_way_tariff(dt, 100.0, is_export=True)
+        self.assertAlmostEqual(price, 10.0, places=2)
+
+    def test_daily_fee_96200(self):
+        interval_time = datetime(2026, 9, 1, 12, 0, tzinfo=BRISBANE)
+        self.assertEqual(energex.get_daily_fee('96200', interval_time=interval_time), 0.651)
+
+    def test_translate_tariff_96200(self):
+        # 96200 must not be truncated
+        self.assertEqual(energex.translate_tariff('96200'), '96200')
+
+    def test_convert_96200_dispatches(self):
+        # Ensure convert() with tariff '96200' reaches convert_two_way_tariff
+        dt = datetime(2026, 1, 15, 18, 5, tzinfo=BRISBANE)  # 18:05 → adjusted to 18:00 → peak
+        price = energex.convert(dt, '96200', 100.0)
+        self.assertAlmostEqual(price, 10.0 + 19.533, places=2)


### PR DESCRIPTION
Adds support for the Energex 2026-27 Residential Two-Way Tariff Trial (NTC 96200).

## Source documents

- **Tariff trial overview (EOI):** https://www.energex.com.au/__data/assets/pdf_file/0008/1848545/2026-27-Residential-Two-Way-Tariff-Trial-EOI-Energex.pdf
- **2026-27 Network Price List (SCS Network Tariffs table, NTC 96200):** https://www.energex.com.au/__data/assets/excel_doc/0010/1985968/Energex-2026-27-Network-Price-List-Updated-for-Sch-8.xlsx
- **2026-27 Pricing Proposal Overview:** https://www.energex.com.au/__data/assets/pdf_file/0011/1985969/Energex-2026-27-Pricing-Proposal-Overview.pdf

## Tariff structure

This is a **seasonal** two-way tariff with distinct import and export periods across summer (Nov–Mar) and non-summer (Apr–Oct) seasons. The tariff does not exist before 1 July 2026 — pre-transition datetimes return spot-only pricing.

### Import rates (c/kWh, ex-GST)
| Period | Season | Time | Rate |
|---|---|---|---|
| Peak | Summer only | 17:00–20:00 | 19.533 |
| Off-Peak | All year | 09:00–15:00 | 0.434 |
| Shoulder | Summer | 20:00–09:00, 15:00–17:00 | 6.069 |
| Shoulder | Non-summer | 15:00–09:00 | 6.069 |

### Export rates (c/kWh, ex-GST)
| Period | Season | Time | Rate |
|---|---|---|---|
| Export Reward | Summer only | 17:00–20:00 | −12.195 (credit) |
| Export Charge | Non-summer only | 11:00–13:00 | +2.210 |
| BEL exempt | Non-summer only | 10:00–11:00 | 0 |
| All other | — | — | 0 |

- Daily charge: $0.651/day
- Source: Energex SCS Network Tariffs 2026-27 (Excluding GST), NTC 96200

## Changes
- `_is_summer()` helper — months 11, 12, 1, 2, 3 in Brisbane time
- `convert_two_way_tariff()` — seasonal import/export logic with `_use_2026_prices()` date guard (returns spot-only before 1 July 2026)
- `translate_tariff()` — guards `96200` from truncation to `9600`
- `tariffs_2026_27` and `daily_fees_2026_27` — `96200` entry added
- `battery_tariffs()` — `Residential` now includes `96200`/`96200X`
- `convert()` — dispatches `96200` to the seasonal handler
- 14 new tests in `test/test_energex.py` (132 total passing)