### PR TITLE
fix: gate SAPN RESELE family peak export credit to summer months only (Nov–Mar)

### DIFF
--- a/aemo_to_tariff/sapower.py
+++ b/aemo_to_tariff/sapower.py
@@ -6,6 +6,10 @@ def time_zone():
     return 'Australia/Adelaide'
 
 
+# Peak export credit for RESELE family applies November–March only (SA summer)
+RESELE_SUMMER_MONTHS = frozenset({11, 12, 1, 2, 3})
+
+
 def battery_tariffs(customer_type: str):
     """
     Get the battery tariff for a given customer type.
@@ -219,7 +223,8 @@ def convert_feed_in_tariff(interval_datetime: datetime, tariff_code: str, rrp: f
     - float: The price in c/kWh.
     """
     interval_datetime = interval_datetime - timedelta(minutes=5)
-    interval_time = interval_datetime.astimezone(ZoneInfo(time_zone())).time()
+    local_dt = interval_datetime.astimezone(ZoneInfo(time_zone()))
+    interval_time = local_dt.time()
     rrp_c_kwh = rrp / 10
 
     feed_in_tariff = feed_in_tariffs.get(tariff_code)
@@ -231,6 +236,11 @@ def convert_feed_in_tariff(interval_datetime: datetime, tariff_code: str, rrp: f
     for period_name, start, end, rate in feed_in_tariff['periods']:
 
         if start <= interval_time < end or (start > end and (interval_time >= start or interval_time < end)):
+            # Gate Peak export credit to summer months for RESELE family
+            if (period_name == 'Peak'
+                    and tariff_code in ('RESELE', 'RESELEX', 'RELE2W', 'SBELE', 'SBELEX')
+                    and local_dt.month not in RESELE_SUMMER_MONTHS):
+                return rrp_c_kwh  # outside summer: no credit, no charge
             total_price = rrp_c_kwh + rate
             return total_price
 

--- a/test/test_sapower.py
+++ b/test/test_sapower.py
@@ -41,15 +41,12 @@ class TestSAPower(unittest.TestCase):
         self.assertAlmostEqual(price * 1.1678, expected_price, places=1, msg=f"Price: {price}, Expected: {expected_price}, Loss Factor: {loss_factor}")
     
     def test_two_way_tou_feed_peak(self):
-        # 299.59 ret (datetime.datetime(2025, 7, 3, 18, 35, tzinfo=zoneinfo.ZoneInfo(key='Australia/Adelaide')), 36.77442044, 31.24656962
+        # July is non-summer — Peak credit does NOT apply; result is spot-only
         interval_time = datetime(2025, 7, 3, 18, 35, tzinfo=ZoneInfo('Australia/Adelaide'))
         tariff_code = 'RELE2W'
         rrp = 299.59
-        expected_price = 36.77
         price = sapower.convert_feed_in_tariff(interval_time, tariff_code, rrp)
-        loss_factor = expected_price / price
-        msg = f"Price: {price}, Expected: {expected_price}, Loss Factor: {loss_factor}"
-        self.assertAlmostEqual(price * 0.871, expected_price, places=1, msg=msg)
+        self.assertAlmostEqual(price, 29.959, places=1)  # rrp/10 only
     
     def test_two_way_tou_feed_off_peak(self):
         # -17.51 ret (datetime.datetime(2025, 7, 4, 7, 40, tzinfo=zoneinfo.ZoneInfo(key='Australia/Adelaide')), -0.88640586, -2.99054519)
@@ -102,6 +99,37 @@ class TestSAPower(unittest.TestCase):
         feed_in_price = sapower.convert_feed_in_tariff(interval_time, tariff_code, rrp)
         msg = f"Feed-in Price: {feed_in_price}, Expected: 1.0"
         self.assertAlmostEqual(feed_in_price, 12.25, places=2, msg=msg)
+
+    def test_resele_peak_credit_summer_only(self):
+        """Peak export credit applies Nov–Mar only."""
+        ADELAIDE = ZoneInfo('Australia/Adelaide')
+        # February (summer) — credit should apply
+        summer = datetime(2026, 2, 15, 18, 0, tzinfo=ADELAIDE)
+        price = sapower.convert_feed_in_tariff(summer, 'RESELE', 0.0)
+        self.assertAlmostEqual(price, 12.25, places=2)
+
+        # July (winter) — no credit, spot only
+        winter = datetime(2026, 7, 15, 18, 0, tzinfo=ADELAIDE)
+        price = sapower.convert_feed_in_tariff(winter, 'RESELE', 0.0)
+        self.assertAlmostEqual(price, 0.0, places=2)
+
+    def test_rele2w_peak_credit_summer_only(self):
+        """Same gate applies to RELE2W."""
+        ADELAIDE = ZoneInfo('Australia/Adelaide')
+        summer = datetime(2026, 2, 15, 18, 0, tzinfo=ADELAIDE)
+        self.assertAlmostEqual(sapower.convert_feed_in_tariff(summer, 'RELE2W', 0.0), 12.25, places=2)
+        winter = datetime(2026, 7, 15, 18, 0, tzinfo=ADELAIDE)
+        self.assertAlmostEqual(sapower.convert_feed_in_tariff(winter, 'RELE2W', 0.0), 0.0, places=2)
+
+    def test_sbele_peak_credit_summer_only(self):
+        """Same gate applies to SBELE."""
+        ADELAIDE = ZoneInfo('Australia/Adelaide')
+        summer = datetime(2026, 2, 15, 18, 0, tzinfo=ADELAIDE)
+        # SBELE FY26 peak rate — check what's in the tariff definition
+        price_summer = sapower.convert_feed_in_tariff(summer, 'SBELE', 0.0)
+        self.assertGreater(price_summer, 0)  # should be positive credit in summer
+        winter = datetime(2026, 7, 15, 18, 0, tzinfo=ADELAIDE)
+        self.assertAlmostEqual(sapower.convert_feed_in_tariff(winter, 'SBELE', 0.0), 0.0, places=2)
 
     def test_morning_tou_tariff(self):
         interval_time = datetime(2025, 3, 30, 8, 55, tzinfo=ZoneInfo('Australia/Adelaide'))


### PR DESCRIPTION
## Issue

Closes part of #19.

SAPN RESELE, RESELEX, RELE2W, SBELE, and SBELEX tariffs include a Peak export credit (12.25 c/kWh in FY26, 13.22 c/kWh in FY27) that applies **17:00–21:00 ACST/ACDT**. However, per the official SAPN AER-approved pricing schedule, this Peak credit is **only available November–March** (the South Australian summer). Outside these months, the 17:00–21:00 window carries no credit — 0 c/kWh network component.

The library was previously emitting the Peak credit year-round, overstating battery export value by ~12 c/kWh every evening for 7 months of the year.

## Fix

Added a `RESELE_SUMMER_MONTHS = frozenset({11, 12, 1, 2, 3})` constant and a seasonal gate in `convert_feed_in_tariff()`: when the matched period is 'Peak' AND the tariff is in the RESELE family AND the month is outside the summer window, the function returns spot-only (no network credit).

The period definitions are unchanged — only the runtime dispatch logic is modified.

## Sources

- SAPN AER-approved FY26 Pricing Proposal and tariff schedule
- Issue #19 analysis: https://gist.github.com/purcell-lab/44f01823b1e3a203b45d2fa0a3fe40a4