### PR TITLE
fix: Endeavour N61 — separate high-season (12.4336 c/kWh) and low-season (3.6837 c/kWh) peak export rates

### DIFF
--- a/aemo_to_tariff/endeavour.py
+++ b/aemo_to_tariff/endeavour.py
@@ -120,6 +120,12 @@ demand_charges = {
     }
 }
 
+# N61 High season (Nov-Mar): 12.4336 c/kWh at 16:00-20:00 business days
+# N61 Low season  (Apr-Oct):  3.6837 c/kWh at 16:00-20:00 business days
+# Solar Soak block 2 charge (-1.9690 c/kWh at 10:00-14:00) applies all year.
+N61_HIGH_SEASON_MONTHS = frozenset({11, 12, 1, 2, 3})
+N61_LOW_SEASON_MONTHS = frozenset({4, 5, 6, 7, 8, 9, 10})
+
 feed_in_tariffs = {
     'N61': {
         'name': 'Residential Electrify',
@@ -129,7 +135,7 @@ feed_in_tariffs = {
             ('Off Peak', time(10, 0), time(14, 0), -1.9690)  # inc GST - correct?
         ],
         'weekdays': [0, 1, 2, 3, 4],
-        'peak_months': [11, 12, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]  # November–March and April-October - see page 19
+        'peak_months': N61_HIGH_SEASON_MONTHS  # High season: November–March - see page 19
     },
     'N95': {
         'name': 'Storage',

--- a/test/test_endeavour.py
+++ b/test/test_endeavour.py
@@ -48,6 +48,31 @@ class TestEndeavour(unittest.TestCase):
         msg = f"Feed-in price for {tariff_code} at {interval_time} should be approximately 0.00"
         self.assertAlmostEqual(feed_in_price, 12.1, places=1, msg=msg)
         
+    def test_N61_low_season_export(self):
+        # Low season (Apr-Oct), business day, 16:00-20:00 -> spot + 3.6837
+        interval_time = datetime(2025, 7, 15, 17, 0, tzinfo=ZoneInfo(time_zone()))
+        feed_in_price = convert_feed_in_tariff(interval_time, 'N61', 0.0)
+        self.assertAlmostEqual(feed_in_price, 3.6837, places=4)
+
+    def test_N61_high_season_export(self):
+        # High season (Nov-Mar), business day, 16:00-20:00 -> spot + 12.4336
+        interval_time = datetime(2025, 1, 15, 17, 0, tzinfo=ZoneInfo(time_zone()))
+        feed_in_price = convert_feed_in_tariff(interval_time, 'N61', 0.0)
+        self.assertAlmostEqual(feed_in_price, 12.4336, places=4)
+
+    def test_N61_solar_soak_charge_year_round(self):
+        # Solar Soak block 2 charge (-1.9690 c/kWh at 10:00-14:00) applies all year
+        # on business days, in both high and low season.
+        from datetime import timedelta
+        for month in range(1, 13):
+            # find the first business day (Mon-Fri) of the month
+            day = datetime(2025, month, 1, 11, 0, tzinfo=ZoneInfo(time_zone()))
+            while day.weekday() >= 5:
+                day = day + timedelta(days=1)
+            feed_in_price = convert_feed_in_tariff(day, 'N61', 0.0)
+            self.assertAlmostEqual(feed_in_price, -1.9690, places=4,
+                                   msg=f"Solar soak charge wrong for month {month}")
+
     def test_convert_high_season_peak(self):
         interval_time = datetime(2023, 1, 15, 17, 0, tzinfo=ZoneInfo(time_zone()))
         tariff_code = 'N71'


### PR DESCRIPTION
## Issue

Addresses Issue #19 finding #3 (MEDIUM).

The N61 (Prosumer Two-way) tariff has two distinct peak export rates:
- **High season (Nov–Mar)**: 12.4336 c/kWh at 16:00–20:00 on business days
- **Low season (Apr–Oct)**: 3.6837 c/kWh at 16:00–20:00 on business days (~3.4× lower)

Previously `peak_months` covered all 12 months, which collapsed both rates and made the season distinction non-functional.

The Solar Soak block 2 charge (−1.9690 c/kWh at 10:00–14:00) is unchanged — it applies all year.

## Source

Issue #19: https://github.com/powston/aemo_to_tariff/issues/19
Analysis gist: https://gist.github.com/purcell-lab/44f01823b1e3a203b45d2fa0a3fe40a4