### PR TITLE
CI: self-hosted runner + CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,41 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: [self-hosted, Linux, X64]
+
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: python
+
+      # This repo has no Advanced Security license, so results cannot be
+      # uploaded to GitHub code scanning; keep the SARIF as an artifact.
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          upload: never
+          output: codeql-results
+
+      - name: Upload CodeQL results artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: codeql-results
+          path: codeql-results

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
 
     permissions:
       security-events: write

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
 
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
 
     strategy:
       matrix:


### PR DESCRIPTION
Moves the `Python package` test workflow to the `[self-hosted, Linux, X64]` runner (matching `powston_ui`). Adds a Python CodeQL analysis workflow — no Advanced Security license on this repo, so results are kept as a build artifact (`upload: never`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)