### PR TITLE
Fix Codex review findings from community tariff PRs

### DIFF
--- a/aemo_to_tariff/convert.py
+++ b/aemo_to_tariff/convert.py
@@ -247,13 +247,15 @@ def estimate_demand_fee(interval_time, network, tariff, demand_kw):
     else:
         return 0.0
 
-def get_periods(network, tariff: str):
+def get_periods(network, tariff: str, interval_time=None):
     """
     Get the periods for a given network and tariff.
 
     Parameter:
     - network (str): The name of the network (e.g., 'Energex', 'Ausgrid', 'Evoenergy').
     - tariff (str): The tariff code.
+    - interval_time (datetime, optional): Selects the price schedule (and
+      season for seasonal tariffs). Defaults to now.
 
     Returns:
     - list: A list of periods for the given tariff.
@@ -261,33 +263,33 @@ def get_periods(network, tariff: str):
     network = network.lower()
 
     if network == 'energex':
-        return energex.get_periods(tariff)
+        return energex.get_periods(tariff, interval_time)
     elif network == 'ausgrid':
-        return ausgrid.get_periods(tariff)
+        return ausgrid.get_periods(tariff, interval_time)
     elif network == 'ergon':
-        return ausgrid.get_periods(tariff)
+        return ausgrid.get_periods(tariff, interval_time)
     elif network == 'evoenergy':
-        return evoenergy.get_periods(tariff)
+        return evoenergy.get_periods(tariff, interval_time)
     elif network == 'sapn':
-        return sapower.get_periods(tariff)
+        return sapower.get_periods(tariff, interval_time)
     elif network == 'tasnetworks':
-        return tasnetworks.get_periods(tariff)
+        return tasnetworks.get_periods(tariff, interval_time)
     elif network == 'endeavour':
-        return endeavour.get_periods(tariff)
+        return endeavour.get_periods(tariff, interval_time)
     elif network == 'essential':
-        return essential.get_periods(tariff)
+        return essential.get_periods(tariff, interval_time)
     elif network == 'victoria':
-        return victoria.get_periods(tariff)
+        return victoria.get_periods(tariff, interval_time)
     elif network == 'jemena':
-        return jemena.get_periods(tariff)
+        return jemena.get_periods(tariff, interval_time)
     elif network == 'powercor':
-        return powercor.get_periods(tariff)
+        return powercor.get_periods(tariff, interval_time)
     elif network == 'united':
-        return united.get_periods(tariff)
+        return united.get_periods(tariff, interval_time)
     elif network == 'ausnet':
-        return ausnet.get_periods(tariff)
+        return ausnet.get_periods(tariff, interval_time)
     else:
-        return energex.get_periods(tariff)
+        return energex.get_periods(tariff, interval_time)
 
 
 def battery_tariffs(network, customer_type: str):

--- a/aemo_to_tariff/energex.py
+++ b/aemo_to_tariff/energex.py
@@ -381,13 +381,22 @@ tariffs_2026_27 = {
     '96200': {
         'name': 'Residential Two-Way Tariff Trial',
         'seasonal': True,
+        # Feed-in sign convention: reward adds to the sell price, charge subtracts.
         'rate': {
             'Peak': 19.533,
             'Shoulder': 6.069,
             'Off-Peak': 0.434,
-            'ExportCharge': 2.210,
-            'ExportReward': -12.195,
-        }
+            'ExportCharge': -2.210,
+            'ExportReward': 12.195,
+        },
+        # Import periods for get_periods(); Peak applies Nov-Mar only — see
+        # convert_two_way_tariff for the seasonal dispatch.
+        'periods': [
+            ('Peak', time(17, 0), time(20, 0), 19.533),
+            ('Off-Peak', time(9, 0), time(15, 0), 0.434),
+            ('Shoulder', time(15, 0), time(17, 0), 6.069),
+            ('Shoulder', time(20, 0), time(9, 0), 6.069),
+        ]
     },
 }
 
@@ -415,6 +424,7 @@ demand_charges_2026_27 = {
     '3600': { 'Peak': 10.289},  # Small Business Demand (legacy)
     '3800': { 'Peak': 7.000},  # Small Business TOU Demand & Energy
     '6900': None,  # Residential Time of Use Energy
+    '96200': None,  # Residential Two-Way Tariff Trial (energy-only)
     '8900': None,  # Small 8900 TOU
     '8800': None,  # Small 8800 TOU
     '7200': {
@@ -614,9 +624,10 @@ def convert_two_way_tariff(interval_datetime: datetime, rrp: float, is_export: b
         Off-Peak: 09:00-15:00  → 0.434 c/kWh
         Shoulder: all other    → 6.069 c/kWh  (no peak period)
 
-    Export periods:
-      Summer:     17:00-20:00  → -12.195 c/kWh (reward/credit)
-      Non-Summer: 11:00-13:00  → +2.210 c/kWh (charge)
+    Export periods (feed-in convention: the return value is the customer's
+    sell price, so a reward raises it and a charge lowers it):
+      Summer:     17:00-20:00  → +12.195 c/kWh (reward/credit)
+      Non-Summer: 11:00-13:00  → -2.210 c/kWh (charge)
                   10:00-11:00  → 0 (BEL exempt)
       All other:               → 0 c/kWh
 
@@ -640,9 +651,9 @@ def convert_two_way_tariff(interval_datetime: datetime, rrp: float, is_export: b
 
     if is_export:
         if summer and time(17, 0) <= t < time(20, 0):
-            network = -12.195  # export reward (credit)
+            network = 12.195  # export reward (credit) — raises the sell price
         elif not summer and time(11, 0) <= t < time(13, 0):
-            network = 2.210   # export charge
+            network = -2.210  # export charge — lowers the sell price
         else:
             network = 0.0     # no charge/reward
         return rrp_c_kwh + network

--- a/aemo_to_tariff/energex.py
+++ b/aemo_to_tariff/energex.py
@@ -541,6 +541,8 @@ def calculate_demand_fee(tariff_code: str, demand_kw: float, days: int = 30, tou
         return 0.0  # Return 0 if the tariff doesn't have a demand charge
 
     charge = charges[tariff_code]
+    if charge is None:
+        return 0.0  # Energy-only tariff (e.g. 6900, 96200) — no demand charge
     if isinstance(charge, dict):
         charge_per_kw_per_month = charge.get(tou, 0.0)
     else:

--- a/aemo_to_tariff/energex.py
+++ b/aemo_to_tariff/energex.py
@@ -389,13 +389,17 @@ tariffs_2026_27 = {
             'ExportCharge': -2.210,
             'ExportReward': 12.195,
         },
-        # Import periods for get_periods(); Peak applies Nov-Mar only — see
-        # convert_two_way_tariff for the seasonal dispatch.
-        'periods': [
+        # get_periods() picks the season-appropriate list; the 17:00-20:00
+        # Peak only exists Nov-Mar and is Shoulder the rest of the year.
+        'periods_summer': [
             ('Peak', time(17, 0), time(20, 0), 19.533),
             ('Off-Peak', time(9, 0), time(15, 0), 0.434),
             ('Shoulder', time(15, 0), time(17, 0), 6.069),
             ('Shoulder', time(20, 0), time(9, 0), 6.069),
+        ],
+        'periods_non_summer': [
+            ('Off-Peak', time(9, 0), time(15, 0), 0.434),
+            ('Shoulder', time(15, 0), time(9, 0), 6.069),
         ]
     },
 }
@@ -587,6 +591,11 @@ def get_periods(tariff_code: str, interval_time=None):
     tariff = get_tariffs(interval_time).get(tariff_code)
     if not tariff:
         raise ValueError(f"Unknown tariff code: {tariff_code}")
+
+    if tariff.get('seasonal'):
+        when = interval_time if interval_time is not None else datetime.now(ZoneInfo(time_zone()))
+        season = 'periods_summer' if _is_summer(when) else 'periods_non_summer'
+        return tariff[season]
 
     return tariff['periods']
 

--- a/aemo_to_tariff/essential.py
+++ b/aemo_to_tariff/essential.py
@@ -174,10 +174,15 @@ tariffs_2025_26 = {
         ]
     },
     'BLNBSS1': {
+        # SS window per the 2025-26 Network Price List: Peak 7am-10am and
+        # 3pm-10pm every day, Off-Peak all other times (same shape as BLNRSS2).
         'name': 'LV Small Business TOU - Sun Soaker',
         'periods': [
-            ('Peak', time(17, 0), time(20, 0), 17.9646),
-            ('Off-Peak', time(22, 0), time(7, 0), 8.1015),
+            ('Peak', time(7, 0), time(9, 59), 17.9646),
+            ('Peak', time(15, 0), time(21, 59), 17.9646),
+            ('Off-Peak', time(0, 0), time(6, 59), 8.1015),
+            ('Off-Peak', time(10, 0), time(14, 59), 8.1015),
+            ('Off-Peak', time(22, 0), time(23, 59), 8.1015),
         ]
     },
 }
@@ -284,10 +289,14 @@ tariffs_2026_27 = {
         ]
     },
     'BLNBSS1': {
+        # Same SS window as 2025-26 (Peak 7-10 and 15-22 every day).
         'name': 'LV Small Business TOU - Sun Soaker',
         'periods': [
-            ('Peak', time(15, 0), time(22, 0), 18.9741),
-            ('Off-Peak', time(22, 0), time(15, 0), 8.5988),
+            ('Peak', time(7, 0), time(9, 59), 18.9741),
+            ('Peak', time(15, 0), time(21, 59), 18.9741),
+            ('Off-Peak', time(0, 0), time(6, 59), 8.5988),
+            ('Off-Peak', time(10, 0), time(14, 59), 8.5988),
+            ('Off-Peak', time(22, 0), time(23, 59), 8.5988),
         ]
     },
 }

--- a/aemo_to_tariff/essential.py
+++ b/aemo_to_tariff/essential.py
@@ -102,11 +102,10 @@ tariffs_2025_26 = {
     'BLNRSS2': {
         'name': 'LV Residential Sun Soaker',
         'periods': [
-            ('Peak', time(7, 0), time(9, 59), 16.9522),
-            ('Peak', time(15, 0), time(21, 59), 16.9522),
-            ('Off-Peak', time(0, 0), time(6, 59), 5.8530),
-            ('Off-Peak', time(10, 0), time(14, 59), 5.8530),
-            ('Off-Peak', time(22, 0), time(23, 59), 5.8530),
+            ('Peak', time(7, 0), time(10, 0), 16.9522),
+            ('Peak', time(15, 0), time(22, 0), 16.9522),
+            ('Off-Peak', time(10, 0), time(15, 0), 5.8530),
+            ('Off-Peak', time(22, 0), time(7, 0), 5.8530),
         ]
     },
     'BLND1AR': {
@@ -178,11 +177,10 @@ tariffs_2025_26 = {
         # 3pm-10pm every day, Off-Peak all other times (same shape as BLNRSS2).
         'name': 'LV Small Business TOU - Sun Soaker',
         'periods': [
-            ('Peak', time(7, 0), time(9, 59), 17.9646),
-            ('Peak', time(15, 0), time(21, 59), 17.9646),
-            ('Off-Peak', time(0, 0), time(6, 59), 8.1015),
-            ('Off-Peak', time(10, 0), time(14, 59), 8.1015),
-            ('Off-Peak', time(22, 0), time(23, 59), 8.1015),
+            ('Peak', time(7, 0), time(10, 0), 17.9646),
+            ('Peak', time(15, 0), time(22, 0), 17.9646),
+            ('Off-Peak', time(10, 0), time(15, 0), 8.1015),
+            ('Off-Peak', time(22, 0), time(7, 0), 8.1015),
         ]
     },
 }
@@ -217,11 +215,10 @@ tariffs_2026_27 = {
     'BLNRSS2': {
         'name': 'LV Residential Sun Soaker',
         'periods': [
-            ('Peak', time(7, 0), time(9, 59), 17.9566),
-            ('Peak', time(15, 0), time(21, 59), 17.9566),
-            ('Off-Peak', time(0, 0), time(6, 59), 6.3275),
-            ('Off-Peak', time(10, 0), time(14, 59), 6.3275),
-            ('Off-Peak', time(22, 0), time(23, 59), 6.3275),
+            ('Peak', time(7, 0), time(10, 0), 17.9566),
+            ('Peak', time(15, 0), time(22, 0), 17.9566),
+            ('Off-Peak', time(10, 0), time(15, 0), 6.3275),
+            ('Off-Peak', time(22, 0), time(7, 0), 6.3275),
         ]
     },
     'BLND1AR': {
@@ -292,11 +289,10 @@ tariffs_2026_27 = {
         # Same SS window as 2025-26 (Peak 7-10 and 15-22 every day).
         'name': 'LV Small Business TOU - Sun Soaker',
         'periods': [
-            ('Peak', time(7, 0), time(9, 59), 18.9741),
-            ('Peak', time(15, 0), time(21, 59), 18.9741),
-            ('Off-Peak', time(0, 0), time(6, 59), 8.5988),
-            ('Off-Peak', time(10, 0), time(14, 59), 8.5988),
-            ('Off-Peak', time(22, 0), time(23, 59), 8.5988),
+            ('Peak', time(7, 0), time(10, 0), 18.9741),
+            ('Peak', time(15, 0), time(22, 0), 18.9741),
+            ('Off-Peak', time(10, 0), time(15, 0), 8.5988),
+            ('Off-Peak', time(22, 0), time(7, 0), 8.5988),
         ]
     },
 }

--- a/aemo_to_tariff/united.py
+++ b/aemo_to_tariff/united.py
@@ -112,7 +112,7 @@ tariffs_2026_27 = {
             ('Off-peak', time(0, 0), time(11, 0), 5.220),
             ('Saver', time(11, 0), time(16, 0), 1.000),
             ('Peak', time(16, 0), time(21, 0), 20.920),
-            ('Off-peak', time(21, 0), time(23, 59), 5.220),
+            ('Off-peak', time(21, 0), time(0, 0), 5.220),  # wraps to midnight so 23:59 is covered
         ]
     },
     'URSTOU': {
@@ -121,7 +121,7 @@ tariffs_2026_27 = {
             ('Off-peak', time(0, 0), time(11, 0), 5.220),
             ('Saver', time(11, 0), time(16, 0), 1.000),
             ('Peak', time(16, 0), time(21, 0), 20.920),
-            ('Off-peak', time(21, 0), time(23, 59), 5.220),
+            ('Off-peak', time(21, 0), time(0, 0), 5.220),  # wraps to midnight so 23:59 is covered
         ]
     },
     'FURTOU': {
@@ -130,7 +130,7 @@ tariffs_2026_27 = {
             ('Off-peak', time(0, 0), time(11, 0), 5.220),
             ('Saver', time(11, 0), time(16, 0), 1.000),
             ('Peak', time(16, 0), time(21, 0), 20.920),
-            ('Off-peak', time(21, 0), time(23, 59), 5.220),
+            ('Off-peak', time(21, 0), time(0, 0), 5.220),  # wraps to midnight so 23:59 is covered
         ]
     },
     'FURDS': {
@@ -139,7 +139,7 @@ tariffs_2026_27 = {
             ('Off-peak', time(0, 0), time(11, 0), 5.220),
             ('Saver', time(11, 0), time(16, 0), 1.000),
             ('Peak', time(16, 0), time(21, 0), 20.920),
-            ('Off-peak', time(21, 0), time(23, 59), 5.220),
+            ('Off-peak', time(21, 0), time(0, 0), 5.220),  # wraps to midnight so 23:59 is covered
         ]
     },
     'URDS': {
@@ -148,7 +148,7 @@ tariffs_2026_27 = {
             ('Off-peak', time(0, 0), time(11, 0), 5.220),
             ('Saver', time(11, 0), time(16, 0), 1.000),
             ('Peak', time(16, 0), time(21, 0), 20.920),
-            ('Off-peak', time(21, 0), time(23, 59), 5.220),
+            ('Off-peak', time(21, 0), time(0, 0), 5.220),  # wraps to midnight so 23:59 is covered
         ]
     },
     'RESKW1R': {
@@ -157,7 +157,7 @@ tariffs_2026_27 = {
             ('Off-peak', time(0, 0), time(11, 0), 5.220),
             ('Saver', time(11, 0), time(16, 0), 1.000),
             ('Peak', time(16, 0), time(21, 0), 20.920),
-            ('Off-peak', time(21, 0), time(23, 59), 5.220),
+            ('Off-peak', time(21, 0), time(0, 0), 5.220),  # wraps to midnight so 23:59 is covered
         ]
     },
     'NDMO21': {

--- a/aemo_to_tariff/united.py
+++ b/aemo_to_tariff/united.py
@@ -151,6 +151,15 @@ tariffs_2026_27 = {
             ('Off-peak', time(21, 0), time(23, 59), 5.220),
         ]
     },
+    'RESKW1R': {
+        'name': 'Residential TOU (URSTOU)',
+        'periods': [
+            ('Off-peak', time(0, 0), time(11, 0), 5.220),
+            ('Saver', time(11, 0), time(16, 0), 1.000),
+            ('Peak', time(16, 0), time(21, 0), 20.920),
+            ('Off-peak', time(21, 0), time(23, 59), 5.220),
+        ]
+    },
     'NDMO21': {
         'name': 'NDMO21 TOU',
         'periods': [
@@ -236,6 +245,7 @@ daily_fees_2026_27 = {
     'URDS': 31.51,
     'FURTOU': 31.51,
     'FURDS': 31.51,
+    'RESKW1R': 31.51,
     'LVM1R': 61.64,
     'LVTOU': 61.64,
     'LVMKW1R': 61.64,

--- a/aemo_to_tariff/victoria.py
+++ b/aemo_to_tariff/victoria.py
@@ -145,7 +145,7 @@ def get_daily_fee(tariff_code: str, annual_usage: float = None):
     # Fee table is transcribed in $/day; the package contract is cents/day.
     return fee * 100 if fee else 0.0
 
-def get_periods(tariff_code: str):
+def get_periods(tariff_code: str, interval_time=None):
     """
     Retrieve the time-of-use periods for a given tariff code.
     """

--- a/test/test_convert.py
+++ b/test/test_convert.py
@@ -192,3 +192,15 @@ class TestTariffConversions(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
+
+    def test_get_periods_threads_interval_time(self):
+        # Package-level get_periods must pass interval_time through so
+        # seasonal tariffs (Energex 96200) return the right season.
+        from aemo_to_tariff import get_periods
+        from zoneinfo import ZoneInfo
+        summer = datetime(2027, 1, 15, 12, 0, tzinfo=ZoneInfo('Australia/Brisbane'))
+        names = {p[0] for p in get_periods('Energex', '96200', summer)}
+        self.assertIn('Peak', names)
+        winter = datetime(2026, 9, 1, 12, 0, tzinfo=ZoneInfo('Australia/Brisbane'))
+        names = {p[0] for p in get_periods('Energex', '96200', winter)}
+        self.assertNotIn('Peak', names)

--- a/test/test_convert.py
+++ b/test/test_convert.py
@@ -189,10 +189,6 @@ class TestTariffConversions(unittest.TestCase):
         interval_time = datetime.strptime('2024-07-05 02:00+09:30', '%Y-%m-%d %H:%M%z')
         self.assertAlmostEqual(spot_to_tariff(interval_time, 'tasnetworks', 'TAS93', 100), 14.537, 2)
 
-
-if __name__ == '__main__':
-    unittest.main()
-
     def test_get_periods_threads_interval_time(self):
         # Package-level get_periods must pass interval_time through so
         # seasonal tariffs (Energex 96200) return the right season.
@@ -204,3 +200,16 @@ if __name__ == '__main__':
         winter = datetime(2026, 9, 1, 12, 0, tzinfo=ZoneInfo('Australia/Brisbane'))
         names = {p[0] for p in get_periods('Energex', '96200', winter)}
         self.assertNotIn('Peak', names)
+
+    def test_energex_96200_demand_fee_is_zero(self):
+        # Energy-only trial tariff: the package demand-fee APIs must return 0,
+        # not raise TypeError on the None demand-charge entry.
+        from aemo_to_tariff import calculate_demand_fee, estimate_demand_fee
+        from zoneinfo import ZoneInfo
+        interval_time = datetime(2026, 9, 1, 18, 0, tzinfo=ZoneInfo('Australia/Brisbane'))
+        self.assertEqual(calculate_demand_fee('Energex', '96200', 5.0, interval_time=interval_time), 0.0)
+        self.assertEqual(estimate_demand_fee(interval_time, 'Energex', '96200', 5.0), 0.0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_energex.py
+++ b/test/test_energex.py
@@ -67,16 +67,16 @@ class TestTwoWayTariff(unittest.TestCase):
         self.assertAlmostEqual(price, 10.0 + 6.069, places=2)
 
     def test_export_reward_summer(self):
-        # Summer export reward: Jan 15, 18:00 → -12.195
+        # Summer export reward raises the sell price: Jan 15, 18:00 → +12.195
         dt = datetime(2027, 1, 15, 18, 0, tzinfo=BRISBANE)
         price = energex.convert_two_way_tariff(dt, 100.0, is_export=True)
-        self.assertAlmostEqual(price, 10.0 - 12.195, places=2)
+        self.assertAlmostEqual(price, 10.0 + 12.195, places=2)
 
     def test_export_charge_nonsummer(self):
-        # Non-summer export charge 11:00-13:00: Jul 15, 12:00 → +2.210
+        # Non-summer export charge 11:00-13:00 lowers the sell price: Jul 15, 12:00 → -2.210
         dt = datetime(2026, 7, 15, 12, 0, tzinfo=BRISBANE)
         price = energex.convert_two_way_tariff(dt, 100.0, is_export=True)
-        self.assertAlmostEqual(price, 10.0 + 2.210, places=2)
+        self.assertAlmostEqual(price, 10.0 - 2.210, places=2)
 
     def test_export_bel_exempt(self):
         # BEL exempt window 10:00-11:00: Jul 15, 10:30 → 0 network
@@ -120,8 +120,22 @@ class TestTwoWayTariff(unittest.TestCase):
     def test_convert_feed_in_tariff_96200x_dispatches(self):
         # Export via the public feed-in API must apply the seasonal reward/charge.
         summer = datetime(2027, 1, 15, 18, 5, tzinfo=BRISBANE)  # adjusted to 18:00 → reward
-        self.assertAlmostEqual(energex.convert_feed_in_tariff(summer, '96200X', 100.0), 10.0 - 12.195, places=2)
+        self.assertAlmostEqual(energex.convert_feed_in_tariff(summer, '96200X', 100.0), 10.0 + 12.195, places=2)
         winter = datetime(2026, 7, 15, 12, 5, tzinfo=BRISBANE)  # adjusted to 12:00 → export charge
-        self.assertAlmostEqual(energex.convert_feed_in_tariff(winter, '96200X', 100.0), 10.0 + 2.210, places=2)
+        self.assertAlmostEqual(energex.convert_feed_in_tariff(winter, '96200X', 100.0), 10.0 - 2.210, places=2)
         # Other tariffs remain spot-only.
         self.assertAlmostEqual(energex.convert_feed_in_tariff(summer, '6900X', 100.0), 10.0, places=2)
+
+    def test_get_periods_96200(self):
+        # get_periods must not raise for the seasonal trial tariff.
+        interval_time = datetime(2026, 9, 1, 12, 0, tzinfo=BRISBANE)
+        periods = energex.get_periods('96200', interval_time=interval_time)
+        names = {p[0] for p in periods}
+        self.assertIn('Peak', names)
+        self.assertIn('Off-Peak', names)
+        self.assertIn('Shoulder', names)
+
+    def test_estimate_demand_fee_96200_is_zero(self):
+        # Energy-only trial tariff must not fall back to the 3700 demand charge.
+        interval_time = datetime(2026, 9, 1, 18, 0, tzinfo=BRISBANE)
+        self.assertEqual(energex.estimate_demand_fee(interval_time, '96200', 5.0), 0.0)

--- a/test/test_energex.py
+++ b/test/test_energex.py
@@ -126,14 +126,15 @@ class TestTwoWayTariff(unittest.TestCase):
         # Other tariffs remain spot-only.
         self.assertAlmostEqual(energex.convert_feed_in_tariff(summer, '6900X', 100.0), 10.0, places=2)
 
-    def test_get_periods_96200(self):
-        # get_periods must not raise for the seasonal trial tariff.
-        interval_time = datetime(2026, 9, 1, 12, 0, tzinfo=BRISBANE)
-        periods = energex.get_periods('96200', interval_time=interval_time)
-        names = {p[0] for p in periods}
-        self.assertIn('Peak', names)
-        self.assertIn('Off-Peak', names)
-        self.assertIn('Shoulder', names)
+    def test_get_periods_96200_seasonal(self):
+        # get_periods must return season-specific periods: the 17:00-20:00
+        # Peak only exists Nov-Mar; outside summer that window is Shoulder.
+        summer = datetime(2027, 1, 15, 12, 0, tzinfo=BRISBANE)
+        names = {p[0] for p in energex.get_periods('96200', interval_time=summer)}
+        self.assertEqual(names, {'Peak', 'Off-Peak', 'Shoulder'})
+        non_summer = datetime(2026, 9, 1, 12, 0, tzinfo=BRISBANE)
+        names = {p[0] for p in energex.get_periods('96200', interval_time=non_summer)}
+        self.assertEqual(names, {'Off-Peak', 'Shoulder'})
 
     def test_estimate_demand_fee_96200_is_zero(self):
         # Energy-only trial tariff must not fall back to the 3700 demand charge.

--- a/test/test_essential.py
+++ b/test/test_essential.py
@@ -1,5 +1,5 @@
 import unittest
-from datetime import datetime
+from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
 import aemo_to_tariff.essential as essential
 from aemo_to_tariff.essential import time_zone, convert_feed_in_tariff, convert
@@ -174,3 +174,14 @@ class TestEssentualPower(unittest.TestCase):
         # 2026-27 rates, same window shape.
         noon_27 = datetime(2026, 8, 17, 12, 0, tzinfo=ZoneInfo(time_zone()))
         self.assertAlmostEqual(convert(noon_27, 'BLNBSS1', 100.0), 10.0 + 8.5988, places=3)
+
+    def test_sun_soaker_no_boundary_gaps(self):
+        # Period bounds are exclusive at the end; exact boundary times like
+        # 09:59/14:59 must not fall through to the Peak fallback.
+        for code, off_rate in (('BLNBSS1', 8.1015), ('BLNRSS2', 5.8530)):
+            for hh, mm in ((6, 59), (14, 59), (23, 59), (12, 0), (4, 0)):
+                dt = datetime(2026, 1, 19, hh, mm, tzinfo=ZoneInfo(time_zone()))
+                # Add 5 min because convert() adjusts the interval end back.
+                dt = dt + timedelta(minutes=5)
+                self.assertAlmostEqual(convert(dt, code, 100.0), 10.0 + off_rate,
+                                       places=3, msg=f"{code} at {hh}:{mm:02d}")

--- a/test/test_essential.py
+++ b/test/test_essential.py
@@ -159,3 +159,18 @@ class TestEssentualPower(unittest.TestCase):
         price_outside = essential.convert_feed_in_tariff(dt_outside, 'BLNREX2', 0.0)
         self.assertGreater(price_inside, price_outside)
 
+
+    def test_blnbss1_full_day_coverage(self):
+        # Business Sun Soaker follows the SS window: Peak 7-10 and 15-22 every
+        # day, Off-Peak all other times. A noon interval must price at
+        # Off-Peak, not fall back to the first (Peak) period.
+        noon = datetime(2026, 1, 19, 12, 0, tzinfo=ZoneInfo(time_zone()))  # Monday
+        self.assertAlmostEqual(convert(noon, 'BLNBSS1', 100.0), 10.0 + 8.1015, places=3)
+        morning_peak = datetime(2026, 1, 19, 8, 0, tzinfo=ZoneInfo(time_zone()))
+        self.assertAlmostEqual(convert(morning_peak, 'BLNBSS1', 100.0), 10.0 + 17.9646, places=3)
+        # Sun Soaker peak is everyday — no weekday gate.
+        sat_evening = datetime(2026, 1, 17, 18, 0, tzinfo=ZoneInfo(time_zone()))
+        self.assertAlmostEqual(convert(sat_evening, 'BLNBSS1', 100.0), 10.0 + 17.9646, places=3)
+        # 2026-27 rates, same window shape.
+        noon_27 = datetime(2026, 8, 17, 12, 0, tzinfo=ZoneInfo(time_zone()))
+        self.assertAlmostEqual(convert(noon_27, 'BLNBSS1', 100.0), 10.0 + 8.5988, places=3)

--- a/test/test_united.py
+++ b/test/test_united.py
@@ -41,3 +41,13 @@ class TestUnited(unittest.TestCase):
         interval_time = datetime(2026, 7, 15, 18, 0, tzinfo=ZoneInfo(time_zone()))
         self.assertAlmostEqual(convert(interval_time, 'RESKW1R', 100.0), 10.0 + 20.92, places=2)
         self.assertEqual(get_daily_fee('RESKW1R', interval_time=interval_time), 31.51)
+
+    def test_urstou_family_covers_end_of_day(self):
+        # The final off-peak period wraps to midnight, so an interval whose
+        # adjusted local time is exactly 23:59 prices at off-peak (5.22) and
+        # does not fall through to the linear approximation. convert()
+        # subtracts 5 min, so pass 00:04 to land on 23:59.
+        end_of_day = datetime(2026, 7, 16, 0, 4, tzinfo=ZoneInfo(time_zone()))
+        for code in ('URSTOU', 'URTOU', 'URDS', 'FURDS', 'FURTOU', 'RESKW1R'):
+            self.assertAlmostEqual(convert(end_of_day, code, 100.0), 10.0 + 5.220,
+                                   places=2, msg=code)

--- a/test/test_united.py
+++ b/test/test_united.py
@@ -34,3 +34,10 @@ class TestUnited(unittest.TestCase):
         # Off-peak resumes outside the Saver window.
         off_peak = datetime(2026, 7, 15, 8, 0, tzinfo=ZoneInfo(time_zone()))
         self.assertAlmostEqual(convert(off_peak, 'URSTOU', 100.0), 10.0 + 5.22, places=2)
+
+    def test_reskw1r_migrates_to_urstou(self):
+        # RESKW1R closed in 2026-27 and migrates to URSTOU; it must price and
+        # return a daily fee rather than raising KeyError.
+        interval_time = datetime(2026, 7, 15, 18, 0, tzinfo=ZoneInfo(time_zone()))
+        self.assertAlmostEqual(convert(interval_time, 'RESKW1R', 100.0), 10.0 + 20.92, places=2)
+        self.assertEqual(get_daily_fee('RESKW1R', interval_time=interval_time), 31.51)


### PR DESCRIPTION
Addresses the Codex review findings left on #20, #22, and #24 after merge.

## Energex 96200 (from #20)
- **P1 — export sign convention inverted.** The feed-in API returns the customer's sell price, so the summer export reward must *add* 12.195 c/kWh and the non-summer charge must *subtract* 2.210 c/kWh — matching how SAPN (`+12.25` Peak) and Essential (`+11.5725` Peak) encode rewards. Previously the incentive was reversed whenever `convert_two_way_tariff(..., is_export=True)` was used.
- **get_periods('96200')** raised `KeyError` — the seasonal entry had no `periods` key. Added the import period list (Peak noted as Nov–Mar only).
- **estimate_demand_fee('96200')** fell back to the 3700 residential demand charge. Added `'96200': None` (energy-only trial tariff).

## Essential BLNBSS1 (from #22)
The 2025-26 table only covered 17:00–20:00 and 22:00–07:00, so daytime intervals fell back to the first (Peak) period. Verified against the official [2025-26 Network Price List](https://www.essentialenergy.com.au/-/media/Project/EssentialEnergy/Website/Files/Our-Network/PriceListAndExplanatoryNotes2025-26.pdf): Sun Soaker (SS) is **Peak 7am–10am and 3pm–10pm every day, Off-Peak all other times** — same shape as BLNRSS2. Fixed both FY tables (the 2026-27 entry also had the wrong shape — it billed the morning peak as off-peak).

## United RESKW1R (from #24)
The migration comment mentioned RESKW1R→URSTOU but no alias was defined, so post-July-2026 conversions raised `KeyError`. Added the URSTOU schedule and 31.51 c/day fee under RESKW1R.

Note: the Codex finding on #26 (`package-ecosystem: python` → `pip`) is already fixed on that branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)