### PR TITLE
Fix powercor feed-in routing and drop duplicate evoenergy branch

### DIFF
--- a/aemo_to_tariff/convert.py
+++ b/aemo_to_tariff/convert.py
@@ -102,12 +102,10 @@ def spot_to_feed_in_tariff(interval_time, network, tariff, rrp,
         return tasnetworks.convert_feed_in_tariff(interval_time, tariff, adjusted_rrp)
     elif network == 'endeavour':
         return endeavour.convert_feed_in_tariff(interval_time, tariff, adjusted_rrp)
-    elif network == 'evoenergy':
-        return evoenergy.convert_feed_in_tariff(interval_time, tariff, adjusted_rrp)
     elif network == 'jemena':
         return jemena.convert_feed_in_tariff(interval_time, tariff, adjusted_rrp)
     elif network == 'powercor':
-        return united.convert_feed_in_tariff(interval_time, tariff, adjusted_rrp)
+        return powercor.convert_feed_in_tariff(interval_time, tariff, adjusted_rrp)
     elif network == 'united':
         return united.convert_feed_in_tariff(interval_time, tariff, adjusted_rrp)
     elif network == 'essential':

--- a/test/test_powercor.py
+++ b/test/test_powercor.py
@@ -1,7 +1,9 @@
 import unittest
+from unittest.mock import patch
 from zoneinfo import ZoneInfo
 from datetime import datetime
 from aemo_to_tariff.powercor import time_zone, convert, get_daily_fee
+from aemo_to_tariff.convert import spot_to_feed_in_tariff
 
 class TestPowercor(unittest.TestCase):
     def test_convert(self):
@@ -24,3 +26,20 @@ class TestPowercor(unittest.TestCase):
         interval_time = datetime(2026, 7, 15, 18, 0, tzinfo=ZoneInfo(time_zone()))
         price = convert(interval_time, 'PRTOU', 100.0)
         self.assertAlmostEqual(price, 10.0 + 22.09, places=2)
+
+    def test_feed_in_dispatches_to_powercor_module(self):
+        # Regression: spot_to_feed_in_tariff used to route powercor exports through
+        # united.convert_feed_in_tariff (a copy-paste bug). Both modules currently
+        # return rrp/10, so patch powercor's feed-in with a sentinel to prove the
+        # wrapper actually dispatches to the powercor module.
+        interval_time = datetime(2026, 7, 9, 12, 30, tzinfo=ZoneInfo(time_zone()))
+        with patch('aemo_to_tariff.powercor.convert_feed_in_tariff', return_value=42.0) as m:
+            result = spot_to_feed_in_tariff(interval_time, 'powercor', 'GENR13', 100.0, dlf=1, mlf=1, market=1)
+        self.assertEqual(result, 42.0)
+        m.assert_called_once()
+
+    def test_feed_in_value(self):
+        # Behavioural lock: powercor export is a straight rrp/10 pass-through.
+        interval_time = datetime(2026, 7, 9, 12, 30, tzinfo=ZoneInfo(time_zone()))
+        price = spot_to_feed_in_tariff(interval_time, 'powercor', 'GENR13', 100.0, dlf=1, mlf=1, market=1)
+        self.assertAlmostEqual(price, 10.0, places=6)


### PR DESCRIPTION
## What

Two small correctness fixes in `spot_to_feed_in_tariff` (`aemo_to_tariff/convert.py`), found while auditing the dispatch functions after the ergon `get_periods` routing fix in #28:

1. **`powercor` feed-in misrouted to `united`** — `elif network == 'powercor': return united.convert_feed_in_tariff(...)` now dispatches to `powercor.convert_feed_in_tariff`.
2. **Duplicate `evoenergy` branch** removed — the second `elif network == 'evoenergy'` was dead code (the first always matched).

## Why

Both are latent, not currently wrong: `powercor` and `united` feed-in are both a plain `rrp/10` pass-through today, so the misroute produces the same number. But the moment powercor gets its own feed-in logic, the wrapper would silently ignore it. Cheap to fix now.

## Tests

- `test_feed_in_dispatches_to_powercor_module`: patches `aemo_to_tariff.powercor.convert_feed_in_tariff` with a sentinel and asserts the wrapper calls it — a value test can't catch the routing while the two modules are identical, so this guards the dispatch directly.
- `test_feed_in_value`: behavioural lock that powercor export is `rrp/10`.

Verified the fixed wrapper does **not** call `united` for powercor exports, and still routes `united` exports to `united`.

Full suite: `nose2` green, 2 pre-existing expected-failures (documented caller-config gaps), no behavioural change to any existing case.

## Not changed

The `evoenergy → return 0.0` in `get_daily_fee` / `calculate_demand_fee` / `estimate_demand_fee` are intentional placeholders (evoenergy fees not implemented), not bugs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)