### PR TITLE
Fix Evoenergy 2026-27 017/018 rate level (3.035 c/kWh low)

### DIFF
--- a/aemo_to_tariff/evoenergy.py
+++ b/aemo_to_tariff/evoenergy.py
@@ -125,6 +125,12 @@ tariffs_2025_26 = {
 }
 
 # AER 2026–27 consolidated stakeholder report (8 May 2026).
+#
+# CAUTION: the 017/018 rates from this source were transcribed from the wrong
+# column (see the note on 017 below). Only 017 has since been reconciled against
+# settled retail data. The 015/016/026/090 rates and every 'fixed_daily_charge'
+# here still come from that original transcription and are unverified -- treat a
+# 2026-27 rate that fell relative to 2025-26 as suspect until checked.
 tariffs_2026_27 = {
     '015': {
         'name': 'Residential TOU Network (closed)',
@@ -152,30 +158,41 @@ tariffs_2026_27 = {
         ],
         'peak_months': [11, 12, 1, 2, 3, 6, 7, 8]
     },
+    # 017/018 rates were first transcribed 3.035 c/kWh too low on EVERY period --
+    # a distribution-only column, missing the flat non-distribution component. The
+    # level error is invisible to any relative check (all periods shifted equally,
+    # so period ratios and the shape of a day still look right); it was caught by
+    # reconciling against settled pass-through retail prices, where the implied
+    # retailer fee jumped from ~1.22 to ~4.56 c/kWh across the 1 July boundary
+    # while the same retailer's fee on another network stayed flat. See
+    # test_evoenergy.TestEvoenergy2026RateLevel.
     '017': {
         'name': 'New Residential TOU Network',
         'periods': [
-            ('Peak', time(7, 0), time(9, 0), 16.049),
-            ('Peak', time(17, 0), time(21, 0), 16.049),
-            ('Solar Soak', time(11, 0), time(15, 0), 1.779),
-            ('Off-peak', time(21, 0), time(7, 0), 4.351),
-            ('Off-peak', time(9, 0), time(11, 0), 4.351),
-            ('Off-peak', time(15, 0), time(17, 0), 4.351)
+            ('Peak', time(7, 0), time(9, 0), 19.084),
+            ('Peak', time(17, 0), time(21, 0), 19.084),
+            ('Solar Soak', time(11, 0), time(15, 0), 4.814),
+            ('Off-peak', time(21, 0), time(7, 0), 7.386),
+            ('Off-peak', time(9, 0), time(11, 0), 7.386),
+            ('Off-peak', time(15, 0), time(17, 0), 7.386)
         ],
         'fixed_daily_charge': 39.331,
         'peak_months': [11, 12, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     },
+    # 018 carries the same energy rates as 017 (it did in 2025-26 too, differing
+    # only on the metering charge), so it takes the same correction. Inferred by
+    # parity -- unlike 017 there is no settled-data reconciliation behind it.
     '018': {
         'name': 'New Residential TOU Network XMC',
         'periods': [
-            ('Peak', time(7, 0), time(9, 0), 16.049),
-            ('Peak', time(17, 0), time(21, 0), 16.049),
-            ('Off-peak', time(7, 0), time(9, 0), 4.351),
-            ('Off-peak', time(17, 0), time(21, 0), 4.351),
-            ('Solar Soak', time(11, 0), time(15, 0), 1.779),
-            ('Off-peak', time(21, 0), time(7, 0), 4.351),
-            ('Off-peak', time(9, 0), time(11, 0), 4.351),
-            ('Off-peak', time(15, 0), time(17, 0), 4.351)
+            ('Peak', time(7, 0), time(9, 0), 19.084),
+            ('Peak', time(17, 0), time(21, 0), 19.084),
+            ('Off-peak', time(7, 0), time(9, 0), 7.386),
+            ('Off-peak', time(17, 0), time(21, 0), 7.386),
+            ('Solar Soak', time(11, 0), time(15, 0), 4.814),
+            ('Off-peak', time(21, 0), time(7, 0), 7.386),
+            ('Off-peak', time(9, 0), time(11, 0), 7.386),
+            ('Off-peak', time(15, 0), time(17, 0), 7.386)
         ],
         'fixed_daily_charge': 39.331,
         'peak_months': [11, 12, 1, 2, 3, 6, 7, 8]

--- a/test/test_evoenergy.py
+++ b/test/test_evoenergy.py
@@ -43,10 +43,12 @@ class TestEvoenergy(unittest.TestCase):
         self.assertAlmostEqual(price * 1.06796, expected_price, places=1)
 
     def test_evoenergy_017_2026_27_peak(self):
-        # Post-1-Jul-2026 New Residential TOU peak: 16.184 → 16.049 (incl 10% GST)
+        # Post-1-Jul-2026 New Residential TOU peak: 16.184 → 19.084 (incl 10% GST).
+        # Was pinned at 16.049 against the original mis-transcribed table; re-based
+        # once settled retail data showed every 2026-27 017 period 3.035 c/kWh low.
         interval_time = datetime(2026, 7, 20, 18, 0, tzinfo=ZoneInfo('Australia/Sydney'))
         price = evoenergy.convert(interval_time, '017', 100.0)
-        self.assertAlmostEqual(price, 10.0 + 16.049 * 1.1, places=2)
+        self.assertAlmostEqual(price, 10.0 + 19.084 * 1.1, places=2)
 
     def test_evoenergy_090_midday(self):
         # Regression: tariff 090 has no peak_months. Previously is_peak_month
@@ -72,3 +74,120 @@ class TestEvoenergy(unittest.TestCase):
         interval_time = datetime(2025, 10, 15, 18, 0, tzinfo=ZoneInfo('Australia/Sydney'))
         price = evoenergy.convert(interval_time, '018', 0.0)
         self.assertAlmostEqual(price, 5.665 * 1.1, places=2)
+
+
+class TestEvoenergy2026RateLevel(unittest.TestCase):
+    """Guard the *absolute level* of the 2026-27 017 rates, not just their shape.
+
+    The 2026-27 rates were originally transcribed 3.035 c/kWh too low on every
+    period. Nothing in a relative check can see that: shift all periods of a
+    tariff by the same amount and the period ratios, the shape of a priced day,
+    and any "peak > off-peak > soak" ordering all still hold. The anchor has to
+    come from outside the table.
+
+    That anchor is settled retail data. On a pass-through (wholesale) retail plan
+    the customer's settled price for an interval decomposes as::
+
+        settled = k * spot + GST * network_rate + fee
+
+    where ``spot`` is the RRP in c/kWh, ``k`` folds the network loss factors and
+    GST into the spot term, and ``fee`` is the retailer's own flat per-kWh charge.
+    ``k`` and ``fee`` are properties of the plan, not of the interval, so three
+    intervals in three different network periods over-determine them: solve from
+    two and the third must fall out.
+
+    The intervals below are real settled (final, not forecast) data for one ACT
+    tariff 017 site, deliberately carrying no site, meter, NMI or account
+    identifier -- RRP is public market data and the settled price is a
+    deterministic function of published rates plus the plan's flat fee.
+
+    The decisive assertion is ``test_implied_retailer_fee_is_plausible``: with the
+    rates too low, the arithmetic still closes perfectly, but it has to absorb the
+    3.34 c/kWh error into ``fee``, pushing it to ~4.56 c/kWh -- far above any real
+    pass-through retail margin, and ~3.3 c/kWh above what the same retailer
+    charged the same site the month before under the 2025-26 rates.
+    """
+
+    # (period, interval, rrp $/MWh, settled retail c/kWh incl GST)
+    SETTLED = [
+        ('Peak', datetime(2026, 7, 24, 19, 10, tzinfo=ZoneInfo('Australia/Sydney')), 77.22, 31.01904113),
+        ('Off-peak', datetime(2026, 7, 24, 16, 30, tzinfo=ZoneInfo('Australia/Sydney')), 81.00, 18.58223738),
+        ('Solar Soak', datetime(2026, 7, 24, 11, 15, tzinfo=ZoneInfo('Australia/Sydney')), 42.80, 11.39746685),
+    ]
+
+    # Same site, same retailer, one month earlier under the 2025-26 rates. Recovered
+    # by the identical solve; the fee is a plan property and should barely move
+    # across a price-year boundary.
+    FEE_2025_26 = 1.2220
+
+    def _network_component(self, interval_time, rrp, settled, k, fee):
+        """The GST-inclusive network charge the settled price implies."""
+        return settled - k * (rrp / 10) - fee
+
+    def _solve_k_and_fee(self):
+        """Solve (k, fee) from the Peak and Off-peak intervals via the table rates."""
+        rows = []
+        for name, interval_time, rrp, settled in self.SETTLED[:2]:
+            # convert() at rrp=0 isolates GST * network_rate for that period.
+            network_c = evoenergy.convert(interval_time, '017', 0.0)
+            rows.append((rrp / 10, settled - network_c))
+        (x1, y1), (x2, y2) = rows
+        k = (y1 - y2) / (x1 - x2)
+        fee = y1 - k * x1
+        return k, fee
+
+    def test_implied_retailer_fee_is_plausible(self):
+        # THE regression test. A flat level error in the table is pushed into the
+        # solved fee, so bounding the fee bounds the level.
+        _, fee = self._solve_k_and_fee()
+        self.assertLess(
+            fee, 2.0,
+            msg=f'implied retailer fee {fee:.4f} c/kWh is too high to be a retail '
+                f'margin -- the 017 network rates are most likely too low',
+        )
+        self.assertGreater(
+            fee, 0.0,
+            msg=f'implied retailer fee {fee:.4f} c/kWh is negative -- the 017 '
+                f'network rates are most likely too high',
+        )
+
+    def test_implied_fee_is_stable_across_the_price_year_boundary(self):
+        # A retailer's flat per-kWh charge does not jump when the AER rates change.
+        _, fee = self._solve_k_and_fee()
+        self.assertAlmostEqual(fee, self.FEE_2025_26, places=2)
+
+    def test_third_period_is_predicted_by_the_other_two(self):
+        # Structural check: confirms the *relative* spacing of the three periods.
+        # Passes even when the level is wrong, which is exactly why it is not
+        # sufficient on its own.
+        k, fee = self._solve_k_and_fee()
+        name, interval_time, rrp, settled = self.SETTLED[2]
+        predicted = k * (rrp / 10) + evoenergy.convert(interval_time, '017', 0.0) + fee
+        self.assertAlmostEqual(predicted, settled, places=3)
+
+    def test_solved_spot_multiplier_is_a_loss_factor_times_gst(self):
+        # Sanity on the other solved unknown: k = DLF * MLF * GST, so a little
+        # over 1.1. Catches a solve that "fits" by distorting the spot term.
+        k, _ = self._solve_k_and_fee()
+        self.assertGreater(k, 1.1)
+        self.assertLess(k, 1.25)
+
+    def test_2026_27_rates_are_not_below_2025_26(self):
+        # The 2026-27 AER update raised these rates. A transcription that lands
+        # below the prior year is the signature of the original bug.
+        for code in ('017', '018'):
+            prior = {name: rate for name, _s, _e, rate in evoenergy.tariffs_2025_26[code]['periods']}
+            for name, _s, _e, rate in evoenergy.tariffs_2026_27[code]['periods']:
+                with self.subTest(tariff=code, period=name):
+                    self.assertGreaterEqual(rate, prior[name])
+
+    def test_017_period_rates_incl_gst(self):
+        # Pin the corrected values directly, so a future edit has to be deliberate.
+        for interval_time, expected_ex_gst in (
+            (datetime(2026, 7, 24, 19, 10, tzinfo=ZoneInfo('Australia/Sydney')), 19.084),
+            (datetime(2026, 7, 24, 16, 30, tzinfo=ZoneInfo('Australia/Sydney')), 7.386),
+            (datetime(2026, 7, 24, 11, 15, tzinfo=ZoneInfo('Australia/Sydney')), 4.814),
+        ):
+            with self.subTest(interval=interval_time.isoformat()):
+                self.assertAlmostEqual(
+                    evoenergy.convert(interval_time, '017', 0.0), expected_ex_gst * 1.1, places=4)

--- a/test/test_observed_cases.py
+++ b/test/test_observed_cases.py
@@ -85,10 +85,14 @@ OBSERVED_CASES = [
     Case('essential', 'BLNREX2', '2026-07-09T12:30:00+10:00', 73.0, 1, 6.4723, 5.9, SELL, 2.0, 'Day(09-16)'),
     Case('essential', 'BLNREX2', '2026-07-09T18:30:00+10:00', 160.9, 1, 27.8112, 26.7, SELL, 2.0, 'Evening(16-21)'),
     Case('essential', 'BLNREX2', '2026-07-09T06:00:00+10:00', 115.4, 1, 11.54, 10.7, SELL, 2.0, 'Overnight(21-09)'),
-    # --- evoenergy: import 017 / export 1999 -- site 881 (market 2.0)
-    Case('evoenergy', '017', '2026-07-09T09:00:00+10:00', 52.0, 1.1, 23.462, 28.1, BUY, 2.0, 'Off-peak'),
-    Case('evoenergy', '017', '2026-07-09T18:00:00+10:00', 176.4, 1.1, 37.3567, 42.3, BUY, 2.0, 'Peak'),
-    Case('evoenergy', '017', '2026-07-09T13:00:00+10:00', 81.5, 1.1, 11.06, 15.8, BUY, 2.0, 'Solar Soak'),
+    # --- evoenergy: import 017 / export 1999 (market 2.0)
+    # Expected values re-based when the 2026-27 017 rates were corrected (every
+    # period was 3.035 c/kWh ex-GST low). That correction also closed these three
+    # against the LocalVolts ground truth -- gaps went 2.6-2.9c -> 0.4-0.7c -- which
+    # is an independent confirmation from a different day to the one that found it.
+    Case('evoenergy', '017', '2026-07-09T09:00:00+10:00', 52.0, 1.1, 26.8005, 28.1, BUY, 2.0, 'Off-peak'),
+    Case('evoenergy', '017', '2026-07-09T18:00:00+10:00', 176.4, 1.1, 40.6952, 42.3, BUY, 2.0, 'Peak'),
+    Case('evoenergy', '017', '2026-07-09T13:00:00+10:00', 81.5, 1.1, 14.3985, 15.8, BUY, 2.0, 'Solar Soak'),
     Case('evoenergy', '1999', '2026-07-09T12:30:00+10:00', 73.0, 1, 7.3, 7.6, SELL, 2.0, 'Day(09-16)'),
     Case('evoenergy', '1999', '2026-07-09T18:30:00+10:00', 160.9, 1, 16.09, 16.7, SELL, 2.0, 'Evening(16-21)'),
     Case('evoenergy', '1999', '2026-07-09T06:00:00+10:00', 115.4, 1, 11.54, 12.0, SELL, 2.0, 'Overnight(21-09)'),
@@ -199,6 +203,17 @@ class TestKnownDiscrepancies(unittest.TestCase):
         # comes out ~54.2c (incl market) vs LV 57.2c.
         self._assert_matches_localvolts(
             Case('ausgrid', 'EA025', '2026-07-09T18:00:00+10:00', 176.4, 1.1, 52.2192, 57.2, BUY, 2.0, 'Peak'))
+
+    def test_evoenergy_017_reconciles_after_the_2026_27_rate_fix(self):
+        """Not expectedFailure: all three evoenergy 017 windows now land inside
+        GROUND_TRUTH_TOL of the LocalVolts settled price. Before the 2026-27 rate
+        correction they were 2.6-2.9 c/kWh short, i.e. outside it. This locks the
+        reconciliation so a future rate edit that reopens the gap fails here.
+        """
+        for case in OBSERVED_CASES:
+            if case.network == 'evoenergy' and case.direction == BUY:
+                with self.subTest(window=case.window):
+                    self._assert_matches_localvolts(case)
 
     @unittest.expectedFailure
     def test_energex_6900_day_market_cost_too_high(self):


### PR DESCRIPTION
## What

The 2026-27 network rates for Evoenergy tariffs **017** and **018** were transcribed from a distribution-only column, dropping a flat non-distribution component. Every period was **3.035 c/kWh ex-GST too low**:

| Period | Was | Now |
| --- | --- | --- |
| Peak | 16.049 | **19.084** |
| Off-peak | 4.351 | **7.386** |
| Solar Soak | 1.779 | **4.814** |

## Why it survived review

The error is invisible to relative checks. All periods shifted by the same amount, so period ratios and the shape of a priced day still look correct — and the table even passes a "did the rates change on 1 July" review, because they did change. Downward, when the AER update raised them.

## How it was found

By reconciling against settled pass-through retail prices. On such a plan:

```
settled = k * spot + GST * network_rate + fee
```

`k` (loss factors × GST) and `fee` (the retailer's flat per-kWh charge) are properties of the plan, not the interval, so three intervals in three periods over-determine them. Solving showed the implied retailer fee **jumping from ~1.22 to ~4.56 c/kWh across the 1 July boundary**, while the same retailer's fee on another network held flat at ~1.30. The reconciliation is exact (zero residual) in both price years, so the level is the only free parameter left.

## Tests

`test_evoenergy.TestEvoenergy2026RateLevel` encodes the reconciliation from three settled intervals, carrying **no site, meter, NMI or account identifiers** (RRP is public market data; the settled price is published rates plus a flat fee).

The decisive assertion bounds the **solved fee**, because that is what absorbs a flat level error. The companion prediction test — solve from two periods, predict the third — **passes even when the level is wrong**, and is documented in-place as insufficient on its own. Also adds a guard that a 2026-27 rate never lands below its 2025-26 value.

Verified by re-injecting the original rates: **7 tests fail**, including the fee bound. A regression test that does not fail on the bug is worthless.

## Re-based expectations

`test_evoenergy_017_2026_27_peak` and the three evoenergy 017 cases in `test_observed_cases.py` were pinning the mis-transcribed output.

Those observed cases are from **2026-07-09**, a different day to the one that surfaced this. The correction independently closes them against their LocalVolts ground truth — gaps **2.6-2.9c → 0.4-0.7c**. That comparison was previously never asserted for evoenergy, so it is now a real (non-xfail) test rather than left unchecked.

## Scope and limits

- Only **017** is backed by settled data.
- **018** takes the same correction **by parity** — it shared 017's energy rates in 2025-26, differing only on the metering charge. Inferred, not measured; commented as such.
- **015/016/026/090** and every `fixed_daily_charge` still come from the original transcription and are **unverified**. Flagged in a source comment, since they may carry the same level error and there is no ground truth for them here.

## Follow-up outside this repo

A version bump and release are needed before `inverter-intelligence` picks this up. Note also that on the site used for this analysis the per-site `market_costs` (2.0 c/kWh vs the plan's real ~1.22) now overshoots by ~0.75c, so this fix moves that site's error from −2.6c to +0.75c rather than closing it — the remaining gap is caller-supplied config, not library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
