### PR TITLE
Gross up the energex 96200 two-way import rate (follow-up to #32)

### DIFF
--- a/aemo_to_tariff/energex.py
+++ b/aemo_to_tariff/energex.py
@@ -680,7 +680,11 @@ def convert_two_way_tariff(interval_datetime: datetime, rrp: float, is_export: b
             network = 0.0     # no charge/reward
         return rrp_c_kwh + network
 
-    # Import
+    # Import. These are the same distributor rates as the main energex table
+    # (0.434 / 6.069 / 19.533), which settled data shows are stored ex-GST and
+    # billed GST-inclusive, so the import side is grossed up like every other
+    # energex import tariff. The export branch above is left alone -- feed-in
+    # credits carry no GST.
     if summer and time(17, 0) <= t < time(20, 0):
         network = 19.533  # Peak
     elif time(9, 0) <= t < time(15, 0):
@@ -688,7 +692,7 @@ def convert_two_way_tariff(interval_datetime: datetime, rrp: float, is_export: b
     else:
         network = 6.069   # Shoulder (summer: 20-09 + 15-17; non-summer: 15-09)
 
-    return rrp_c_kwh + network
+    return rrp_c_kwh + network * GST
 
 
 def convert(interval_datetime: datetime, tariff_code: str, rrp: float):

--- a/test/test_energex.py
+++ b/test/test_energex.py
@@ -40,31 +40,31 @@ class TestTwoWayTariff(unittest.TestCase):
         # Summer peak: Jan 15, 18:00 → Peak rate 19.533
         dt = datetime(2027, 1, 15, 18, 0, tzinfo=BRISBANE)
         price = energex.convert_two_way_tariff(dt, 100.0, is_export=False)
-        self.assertAlmostEqual(price, 10.0 + 19.533, places=2)
+        self.assertAlmostEqual(price, 10.0 + 19.533 * 1.1, places=2)
 
     def test_import_offpeak_summer(self):
         # Summer off-peak: Jan 15, 12:00 → Off-Peak 0.434
         dt = datetime(2027, 1, 15, 12, 0, tzinfo=BRISBANE)
         price = energex.convert_two_way_tariff(dt, 100.0, is_export=False)
-        self.assertAlmostEqual(price, 10.0 + 0.434, places=2)
+        self.assertAlmostEqual(price, 10.0 + 0.434 * 1.1, places=2)
 
     def test_import_shoulder_summer(self):
         # Summer shoulder: Jan 15, 21:00 → Shoulder 6.069
         dt = datetime(2027, 1, 15, 21, 0, tzinfo=BRISBANE)
         price = energex.convert_two_way_tariff(dt, 100.0, is_export=False)
-        self.assertAlmostEqual(price, 10.0 + 6.069, places=2)
+        self.assertAlmostEqual(price, 10.0 + 6.069 * 1.1, places=2)
 
     def test_import_offpeak_nonsummer(self):
         # Non-summer off-peak: Jul 15, 12:00 → Off-Peak 0.434
         dt = datetime(2026, 7, 15, 12, 0, tzinfo=BRISBANE)
         price = energex.convert_two_way_tariff(dt, 100.0, is_export=False)
-        self.assertAlmostEqual(price, 10.0 + 0.434, places=2)
+        self.assertAlmostEqual(price, 10.0 + 0.434 * 1.1, places=2)
 
     def test_import_shoulder_nonsummer(self):
         # Non-summer shoulder (no peak period): Jul 15, 18:00 → Shoulder 6.069
         dt = datetime(2026, 7, 15, 18, 0, tzinfo=BRISBANE)
         price = energex.convert_two_way_tariff(dt, 100.0, is_export=False)
-        self.assertAlmostEqual(price, 10.0 + 6.069, places=2)
+        self.assertAlmostEqual(price, 10.0 + 6.069 * 1.1, places=2)
 
     def test_export_reward_summer(self):
         # Summer export reward raises the sell price: Jan 15, 18:00 → +12.195
@@ -115,7 +115,7 @@ class TestTwoWayTariff(unittest.TestCase):
         # Ensure convert() with tariff '96200' reaches convert_two_way_tariff
         dt = datetime(2027, 1, 15, 18, 5, tzinfo=BRISBANE)  # 18:05 → adjusted to 18:00 → peak
         price = energex.convert(dt, '96200', 100.0)
-        self.assertAlmostEqual(price, 10.0 + 19.533, places=2)
+        self.assertAlmostEqual(price, 10.0 + 19.533 * 1.1, places=2)
 
     def test_convert_feed_in_tariff_96200x_dispatches(self):
         # Export via the public feed-in API must apply the seasonal reward/charge.


### PR DESCRIPTION
Follow-up to #32, which was merged before this could land on it.

## What

`convert()` returns early through `convert_two_way_tariff()` for Energex tariff **96200**, so that helper never reaches the GST-adjusted path #32 added. Its import branch still returned the raw network rate, leaving the one supported two-way import tariff understated by 10% of its network component — up to **1.9533 c/kWh** on the summer peak — unlike every other Energex import tariff.

## Why this is inside the evidence, not an inference beyond it

96200's import rates are **0.434 / 6.069 / 19.533**. Those are the exact values the main Energex table carries, and precisely the figures the settled-price reconciliation in #32 showed are stored ex-GST and billed GST-inclusive. Same distributor, same rate figures, same statutory 10%.

That is *not* true of the seven networks #32 deliberately left alone (tasnetworks, jemena, powercor, united, victoria, ausnet, auroraenergy), where the stored rates could plausibly already include GST and there is no settled data to say either way. So this closes a real gap in #32's scope rather than widening it.

## Scope

- **Export branch unchanged** — feed-in credits carry no GST, so the `12.195` reward and `-2.210` charge stay as they are.
- **Pre-1-July-2026 spot-only path untouched.**
- **No site currently uses 96200**, so there is no live pricing impact either way. Worth fixing regardless: the inconsistency is silent, and it would bite the first site placed on the trial tariff.

## Tests

The five import assertions in `TestTwoWayTariff` are grossed up; the four export assertions and the two spot-only assertions are left exactly as they were, which is the check that the change did not leak into the export side.

180 tests OK, 2 expected failures. flake8 count unchanged from baseline.

## Provenance

Raised by Codex on #32 ([comment](https://github.com/powston/aemo_to_tariff/pull/32#discussion_r3649832604)) after that PR had already been merged, so it could not be addressed in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
