### PR TITLE
Bump version to 0.7.27 so the 96200 fix can ship

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aemo_to_tariff"
-version = "0.7.26"
+version = "0.7.27"
 description = "Convert spot prices from $/MWh to c/kWh for different networks and tariffs"
 authors = [
     {name = "Ian Connor", email = "ian@powston.com"}

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='aemo_to_tariff',
-    version='0.7.26',
+    version='0.7.27',
     description='Convert spot prices from $/MWh to c/kWh for different networks and tariffs',
     author='Ian Connor',
     author_email='ian@powston.com',


### PR DESCRIPTION
Bumps `0.7.26` → `0.7.27` so #33 can actually ship.

## Why this is needed, not just tidy

**#33 is merged to master but is not in any published artifact**, and `master` currently claims a version that already exists on PyPI with different code.

The ordering that caused it:

| time | commit |
| --- | --- |
| 17:34 | #32 merged (network GST) |
| 17:35 | `Version bump` → 0.7.26 |
| — | **0.7.26 published to PyPI** |
| 19:06 | #33 merged (energex 96200 two-way import) |

So the release was cut between the two merges. I verified it against the published wheel rather than inferring it:

```
$ pip download aemo_to_tariff==0.7.26 --no-deps
$ python -c "...read energex.py from the wheel..."
two-way return lines in published 0.7.26: ['return rrp_c_kwh + network', 'return rrp_c_kwh + network']
has GST constant: True
```

The published `0.7.26` therefore contains #31 and #32 but **not** #33 — its two-way import path still returns the un-grossed network rate.

Two consequences worth fixing together:

1. **#33 never reaches production** without a new version, so the energex 96200 import path stays 10% light on its network component (up to 1.9533 c/kWh on the summer peak).
2. **`master` ≠ published `0.7.26`.** Anyone who installs or pins that version gets pre-#33 code while the source tree says otherwise. That is the kind of discrepancy that costs someone an afternoon later.

## Scope

Version only — `setup.py` and `pyproject.toml`. No code change; #33 is already on master.

180 tests OK, 2 expected failures.

## After merging

A release needs cutting for this to have any effect. Until `0.7.27` is installed, production keeps the published `0.7.26` behaviour.

Note for sequencing: `set_market_costs_from_settled.py` (powston/inverter-intelligence#518, now merged) probes the installed library and refuses to run until the GST-inclusive version is present. It is satisfied by the published `0.7.26` already, so it is not blocked on this release — but it is worth running only after whichever version you intend to settle on is deployed, so the measurement and the runtime agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
